### PR TITLE
short names must be <= 10 chars when used as filteres

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400DatabaseSchema.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400DatabaseSchema.java
@@ -7,6 +7,7 @@ package io.debezium.connector.db2as400;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,8 +57,8 @@ public class As400DatabaseSchema extends RelationalDatabaseSchema implements Sch
         TableId id = table.id();
         // store in the short name
         // used directly by the decoder
-        final String systemTableName = jdbcConnection.getSystemName(id.schema(), id.table());
-        map.put(id.catalog() + id.schema() + systemTableName, tableInfo);
+        final Optional<String> systemTableNameOpt = jdbcConnection.getSystemName(id.schema(), id.table());
+        systemTableNameOpt.map(systemTableName -> map.put(id.catalog() + id.schema() + systemTableName, tableInfo));
 
         // and store the long name
         // use for serialisation

--- a/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/RetrieveJournal.java
+++ b/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/RetrieveJournal.java
@@ -155,6 +155,7 @@ public class RetrieveJournal {
 		JournalPosition currentPosition = null;
 		if (!hasMoreData && filteirng) { // we didn't have any more data last time
 		    currentPosition = JournalInfoRetrieval.getCurrentPosition(as400.connection(), journalInfo);
+		    currentPosition.setProcessed(true);
 		}
 		hasMoreData = false;
 		


### PR DESCRIPTION
character limit in QjoRetrieveJournalEntries filters requires that table names are <=10 characters filter out those we can't resolve and log an error