### PR TITLE
Improve CPF7060 logging

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
@@ -126,7 +126,7 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
                     retries = 0;
                 }
                 catch (InvalidPositionException e) {
-                    log.error("Invalid posision resetting offsets to beginning", e);
+                    log.error("Invalid position resetting offsets to beginning", e);
                     offsetContext.setPosition(new JournalPosition());
                 }
                 catch (InterruptedException e) {

--- a/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/RetrieveJournal.java
+++ b/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/RetrieveJournal.java
@@ -30,6 +30,7 @@ import com.ibm.as400.access.AS400Bin4;
 import com.ibm.as400.access.AS400Message;
 import com.ibm.as400.access.AS400Structure;
 import com.ibm.as400.access.AS400Text;
+import com.ibm.as400.access.MessageFile;
 import com.ibm.as400.access.ProgramParameter;
 import com.ibm.as400.access.ServiceProgramCall;
 
@@ -200,6 +201,12 @@ public class RetrieveJournal {
         			}
         			case "CPF7054": { // e.g. last < first
         			  throw new InvalidPositionException(String.format("Call failed position %s failed to find offset or invalid offsets: %s", position, id.getText()));
+        			}
+					case "CPF7060": { // object in filter doesn't exist, or was not journaled 
+						id.load(MessageFile.RETURN_FORMATTING_CHARACTERS);
+						throw new InvalidPositionException(
+        			    	String.format("Call failed position %s object not found or not journaled: %s", position, id.getHelp())
+						);
         			}
         			case "CPF7062": {
         			    log.debug("Call failed position {} no data received, probably all filtered: {}", position, id.getText());


### PR DESCRIPTION
CPF7060 indicates that one of the objects in the filters for receiving journal entries doesn't exist, or isn't journaled in the specified receiver range.

Unfortunately, the object at fault that causes a CPF7060 message is hidden away in the second level message text. This PR improves the logging in this situation, helping us more effectively diagnose the problem.