### PR TITLE
Include library on file filters for journal

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorTask.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorTask.java
@@ -16,6 +16,8 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fnz.db2.journal.retrieve.FileFilter;
+
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.connector.base.ChangeEventQueue;
@@ -100,7 +102,7 @@ public class As400ConnectorTask extends BaseSourceTask<As400Partition, As400Offs
 
         final As400StreamingChangeEventSourceMetrics streamingMetrics = new As400StreamingChangeEventSourceMetrics(taskContext, queue, metadataProvider);
         
-        List<String> shortIncludes = jdbcConnection.shortIncludes(schema.getSchemaName(), newConfig.tableIncludeList());
+        List<FileFilter> shortIncludes = jdbcConnection.shortIncludes(schema.getSchemaName(), newConfig.tableIncludeList());
         
         As400RpcConnection rpcConnection = new As400RpcConnection(connectorConfig, streamingMetrics, shortIncludes);
 

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import com.fnz.db2.journal.retrieve.Connect;
+import com.fnz.db2.journal.retrieve.FileFilter;
 import com.fnz.db2.journal.retrieve.JournalInfo;
 import com.fnz.db2.journal.retrieve.JournalInfoRetrieval;
 import com.fnz.db2.journal.retrieve.JournalPosition;
@@ -42,7 +43,7 @@ public class As400RpcConnection implements AutoCloseable, Connect<AS400, IOExcep
     private final LogLimmiting infrequent = new LogLimmiting(60 * 60 * 1000);
 
 
-    public As400RpcConnection(As400ConnectorConfig config, As400StreamingChangeEventSourceMetrics streamingMetrics, List<String> includes) {
+    public As400RpcConnection(As400ConnectorConfig config, As400StreamingChangeEventSourceMetrics streamingMetrics, List<FileFilter> includes) {
         super();
         this.config = config;
         this.streamingMetrics = streamingMetrics;

--- a/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/FileFilter.java
+++ b/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/FileFilter.java
@@ -1,0 +1,18 @@
+package com.fnz.db2.journal.retrieve;
+
+public class FileFilter {
+    private final String schema;
+    private final String tableName;
+    
+    public FileFilter(String schema, String tableName) {
+        this.schema = schema;
+        this.tableName = tableName;
+    }
+
+    public String getSchema() {
+        return schema;
+    }
+    public String getTableName() {
+        return tableName;
+    }
+}

--- a/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/RetrievalCriteria.java
+++ b/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/RetrievalCriteria.java
@@ -196,7 +196,7 @@ public class RetrievalCriteria {
 		addStructureData(curKey, temp2Structure, temp2);
 	}
 	
-	   /**
+    /**
      * Add retrieval criteria 16: FILE. Input parameter must be one of the
      *          BINARY(4)   Number in array
      *  Note: These fields repeat for each file member.
@@ -204,12 +204,12 @@ public class RetrievalCriteria {
      *           CHAR(10)    Library name
      *           CHAR(10)    Member name 
      * 
-     * @param value
+     * @param fileFilters
      */
-    public void addFILE(String library, List<String> files) {
-        if (files == null)
+	public void addFILE(List<FileFilter> fileFilters) {
+        if (fileFilters == null)
             return;
-        int length = files.size();
+        int length = fileFilters.size();
         if (length > 300) {
             log.error("unable to filter for more than 300 files requested length was {}", length);
             return;
@@ -220,13 +220,12 @@ public class RetrievalCriteria {
         fdata[0] = Integer.valueOf(length);
         types[0] = BIN4;
 
-        String paddedLib = StringHelpers.padRight(library, 10);
         int i = 1;
-        for (String file: files) {
+        for (FileFilter f: fileFilters) {
             types[i] = TEXT10;
-            fdata[i++] = StringHelpers.padRight(file.toUpperCase(), 10);
+            fdata[i++] = StringHelpers.padRight(f.getTableName().toUpperCase(), 10);
             types[i] = TEXT10;
-            fdata[i++] = paddedLib;
+            fdata[i++] = StringHelpers.padRight(f.getSchema().toUpperCase(), 10);
             types[i] = TEXT10;
             fdata[i++] = "*ALL      ";
         }

--- a/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/RetrieveJournal.java
+++ b/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/RetrieveJournal.java
@@ -62,7 +62,7 @@ public class RetrieveJournal {
 	private final int journalBufferSize;
 	private long totalTransferred = 0;
 	private final boolean filterCodes;
-	private final List<String> includeFiles;
+	private final List<FileFilter> includeFiles;
 	private boolean hasMoreData = true;
 	private final boolean filteirng;
 	private final JournalInfo journalInfo;
@@ -71,7 +71,7 @@ public class RetrieveJournal {
 		this(as400, journalLib, null, ParameterListBuilder.DEFAULT_JOURNAL_BUFFER_SIZE, true, null);
 	}
 	
-	public RetrieveJournal(Connect<AS400, IOException> as400, JournalInfo journalLib, int journalBufferSize, boolean filterCodes, List<String> includeFiles) {
+	public RetrieveJournal(Connect<AS400, IOException> as400, JournalInfo journalLib, int journalBufferSize, boolean filterCodes, List<FileFilter> includeFiles) {
 		this(as400, journalLib, null, journalBufferSize, true, includeFiles);
 	}
 	
@@ -79,7 +79,7 @@ public class RetrieveJournal {
 		this(as400, journalLib, dumpFolder, ParameterListBuilder.DEFAULT_JOURNAL_BUFFER_SIZE, true, null);
 	}
 	
-	public RetrieveJournal(Connect<AS400, IOException> as400, JournalInfo journalInfo, String dumpFolder, int journalBufferSize, boolean filterCodes, List<String> includeFiles) {
+	public RetrieveJournal(Connect<AS400, IOException> as400, JournalInfo journalInfo, String dumpFolder, int journalBufferSize, boolean filterCodes, List<FileFilter> includeFiles) {
 	    this.filterCodes = filterCodes;
 		this.journalBufferSize = journalBufferSize;
 		if (includeFiles != null) {
@@ -135,7 +135,7 @@ public class RetrieveJournal {
 		builder.init();
 		builder.withJournalEntryType(JournalEntryType.ALL);
         if (includeFiles != null && !includeFiles.isEmpty()) {
-            builder.filterFiles(includeFiles);
+            builder.withFileFilters(includeFiles);
         }
 
 		if (position.isOffsetSet()) {
@@ -449,10 +449,10 @@ public class RetrieveJournal {
 		    return this;
 		}
 
-	      public ParameterListBuilder filterFiles(List<String> includeFiles) {
-	            criteria.addFILE(this.receiverLibrary, includeFiles);
-	            return this;
-	        }
+		public ParameterListBuilder withFileFilters(List<FileFilter> tableFilters) {
+			criteria.addFILE(tableFilters);
+	        return this;
+	    }
 		
 		public ParameterListBuilder filterJournalEntryType(RetrievalCriteria.JournalEntryType[] codes) {
             criteria.addEntTyp(codes);

--- a/journal-parsing/src/main/java/com/fnz/db2/journal/test/CommitLogProcessor.java
+++ b/journal-parsing/src/main/java/com/fnz/db2/journal/test/CommitLogProcessor.java
@@ -7,14 +7,18 @@ import java.io.PrintWriter;
 import java.math.BigInteger;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fnz.db2.journal.retrieve.Connect;
+import com.fnz.db2.journal.retrieve.FileFilter;
 import com.fnz.db2.journal.retrieve.JdbcFileDecoder;
 import com.fnz.db2.journal.retrieve.JournalEntryType;
 import com.fnz.db2.journal.retrieve.JournalInfo;
@@ -50,10 +54,13 @@ public class CommitLogProcessor {
         if (offset != null && receiver != null)
             nextPosition = new JournalPosition(new BigInteger(offset), receiver, journalLib.receiverLibrary, false);
         
-        List<String> includes = null;
+        List<FileFilter> includes = new ArrayList<FileFilter>();
         String includesEnv = System.getenv("ISERIES_INCLUDES");
-        if (includesEnv != null)
-            includes = Arrays.asList(includesEnv.split(","));
+        if (includesEnv != null) {
+			for (String i : Arrays.asList(includesEnv.split(","))) {
+				includes.add(new FileFilter(schema, i));
+			}
+		}
 
 		String database = JdbcFileDecoder.getDatabaseName(sqlConnect.connection());
 		fileDecoder = new JdbcFileDecoder(sqlConnect, database, schemaCache);


### PR DESCRIPTION
The journal receiver library was being used to add file filters to the Retrieve Journal Entry API. Unfortunately this doesn't work in the case where the journal lives in a different library to that of the database tables being included.