### PR TITLE
Throw a better exception for CPF7060

### DIFF
--- a/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/exception/InvalidJournalFilterException.java
+++ b/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/exception/InvalidJournalFilterException.java
@@ -1,0 +1,22 @@
+package com.fnz.db2.journal.retrieve.exception;
+
+public class InvalidJournalFilterException extends Exception {
+
+    public InvalidJournalFilterException(String message) {
+        super(message);
+    }
+
+    public InvalidJournalFilterException(Throwable cause) {
+        super(cause);
+    }
+
+    public InvalidJournalFilterException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidJournalFilterException(String message, Throwable cause, boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+    
+}


### PR DESCRIPTION
The "Invalid Position" exception causes some unwanted behaviour
upstream, causing it to restart from the beginning of the journal. It
makes sense to distinguish cases like CPF7060, which are more likely
than not going to be a config error.

Also, integrate the extended message text logging into the other
exception handling, where this information would be useful.