### PR TITLE
jt400 only works for dates between 1940 and 2039 otherwise returns null

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400JdbcConnection.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400JdbcConnection.java
@@ -37,7 +37,7 @@ import io.debezium.relational.Tables.TableFilter;
 public class As400JdbcConnection extends JdbcConnection implements Connect<Connection, SQLException> {
     private static final Logger log = LoggerFactory.getLogger(As400JdbcConnection.class);
     private static final String URL_PATTERN = "jdbc:as400://${" + JdbcConfiguration.HOSTNAME + "}/${"
-            + JdbcConfiguration.DATABASE + "};thread used=false";
+            + JdbcConfiguration.DATABASE + "};thread used=false;date format=iso;keep alive = true";
     private final JdbcConfiguration config;
 
     private static final String GET_DATABASE_NAME = "SELECT CURRENT_SERVER FROM SYSIBM.SYSDUMMY1";

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<name>parent project for debezium-connector-ibmi</name>
 
 	<properties>
-		<jt400.version>10.6</jt400.version>
+		<jt400.version>11.0</jt400.version>
 		<revision>1.0.0-SNAPSHOT</revision>
 		<log4j2.version>2.18.0</log4j2.version>
 		<slf4j.version>1.7.29</slf4j.version>


### PR DESCRIPTION
performance is also abysmal
simply changing the default to `date format=iso` fixes this