### PR TITLE
fix journal receiver name

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ChangeEventSourceFactory.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ChangeEventSourceFactory.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.connector.db2as400;
 
-import io.debezium.connector.db2as400.metrics.As400StreamingChangeEventSourceMetrics;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;

--- a/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/JournalInfoRetrieval.java
+++ b/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/JournalInfoRetrieval.java
@@ -115,6 +115,7 @@ public class JournalInfoRetrieval {
 		};
 
 		return callServiceProgram(as400, "/QSYS.LIB/QJOURNAL.SRVPGM", "QjoRetrieveJournalInformation", parameters, (byte[] data) -> {
+			// Attached journal receiver name. The name of the journal receiver that is currently attached to this journal. This field will be blank if no journal receivers are attached.
 			String journalReceiver = decodeString(data, 200, 10);
 			String journalLibrary = decodeString(data, 210, 10);
 			return new JournalInfo(journalReceiver, journalLibrary);

--- a/journal-parsing/src/main/java/com/fnz/db2/journal/test/JournalFilterTimeout.java
+++ b/journal-parsing/src/main/java/com/fnz/db2/journal/test/JournalFilterTimeout.java
@@ -1,0 +1,87 @@
+package com.fnz.db2.journal.test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.math.BigInteger;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fnz.db2.journal.retrieve.Connect;
+import com.fnz.db2.journal.retrieve.FileFilter;
+import com.fnz.db2.journal.retrieve.JdbcFileDecoder;
+import com.fnz.db2.journal.retrieve.JournalInfo;
+import com.fnz.db2.journal.retrieve.JournalInfoRetrieval;
+import com.fnz.db2.journal.retrieve.JournalPosition;
+import com.fnz.db2.journal.retrieve.RetrieveConfig;
+import com.fnz.db2.journal.retrieve.RetrieveConfigBuilder;
+import com.fnz.db2.journal.retrieve.RetrieveJournal;
+import com.fnz.db2.journal.retrieve.SchemaCacheHash;
+import com.fnz.db2.journal.retrieve.rnrn0200.DetailedJournalReceiver;
+import com.ibm.as400.access.AS400;
+
+public class JournalFilterTimeout {
+	private static final Logger log = LoggerFactory.getLogger(CommitLogProcessor.class);
+	
+	private static SchemaCacheHash schemaCache = new SchemaCacheHash();
+
+	public static void main(String[] args) throws Exception {
+	    TestConnector connector = new TestConnector();
+	    Connect<AS400, IOException> as400Connect = connector.getAs400();
+	    Connect<Connection, SQLException> sqlConnect = connector.getJdbc();
+	    String schema = connector.getSchema();
+	    
+		JournalPosition nextPosition = new JournalPosition((BigInteger)null, null, null, false);
+
+        JournalInfo journalLib = JournalInfoRetrieval.getJournal(as400Connect.connection(), schema);
+
+        String offset =  System.getenv("ISERIES_OFFSET");
+        String receiver =  System.getenv("ISERIES_RECEIVER");
+        if (offset != null && receiver != null)
+            nextPosition = new JournalPosition(new BigInteger(offset), receiver, journalLib.receiverLibrary, false);
+        
+        List<FileFilter> includes = new ArrayList<FileFilter>();
+        String includesEnv = System.getenv("ISERIES_INCLUDES");
+        if (includesEnv != null) {
+			for (String i : Arrays.asList(includesEnv.split(","))) {
+				includes.add(new FileFilter(schema, i));
+			}
+		}
+
+		String database = JdbcFileDecoder.getDatabaseName(sqlConnect.connection());
+		JdbcFileDecoder fileDecoder = new JdbcFileDecoder(sqlConnect, database, schemaCache);
+		
+		List<DetailedJournalReceiver> receivers = JournalInfoRetrieval.getReceivers(as400Connect.connection(), journalLib);
+		DetailedJournalReceiver first = receivers.stream().min((x, y) -> x.start().compareTo(y.start())).get();
+		
+        JournalPosition endPosition = JournalInfoRetrieval.getCurrentPosition(as400Connect.connection(), journalLib);
+		log.info("start {} end {}", first, endPosition);
+		
+		
+		
+		try (PrintWriter pw = new PrintWriter(new File("exceptions.txt"))) {
+			JournalInfo journal = JournalInfoRetrieval.getJournal(as400Connect.connection(), schema);
+			log.info("journal: " + journal);
+			RetrieveConfig config = new RetrieveConfigBuilder().withAs400(as400Connect).withJournalInfo(journal).withDumpFolder("./bad-journal").withServerFiltering(true).withIncludeFiles(includes).build();
+			RetrieveJournal rj = new RetrieveJournal(config);
+
+			JournalPosition p = new JournalPosition(first.start(), first.info().name(), first.info().library(), false); 
+			long start = System.currentTimeMillis();
+			boolean success = rj.retrieveJournal(p);
+			long end = System.currentTimeMillis();
+//			while (r.nextEntry()) {
+//				;
+//			}
+			log.info("success: {} position: {} time: {} ", success, rj.getPosition(), (end-start)/1000.0);
+
+		}
+	}
+
+}

--- a/journal-parsing/src/test/java/com/fnz/db2/journal/retrieve/RetrieveJournalTest.java
+++ b/journal-parsing/src/test/java/com/fnz/db2/journal/retrieve/RetrieveJournalTest.java
@@ -1,0 +1,93 @@
+package com.fnz.db2.journal.retrieve;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import com.fnz.db2.journal.retrieve.RetrievalCriteria.JournalCode;
+import com.fnz.db2.journal.retrieve.rnrn0200.DetailedJournalReceiver;
+import com.fnz.db2.journal.retrieve.rnrn0200.JournalReceiverInfo;
+import com.fnz.db2.journal.retrieve.rnrn0200.JournalStatus;
+
+public class RetrieveJournalTest {
+
+	private RetrieveJournal createTestSubject() {
+		return new RetrieveJournal(new RetrieveConfig(null, new JournalInfo("receiver", "lib"), 65535, true, new JournalCode[0], new ArrayList<FileFilter>(), RetrieveConfig.DEFAULT_MAX_SERVER_SIDE_ENTRIES, null));
+	}
+
+	@Test
+	public void testLimitEndPositionShouldLimit() throws Exception {
+		RetrieveJournal testSubject = createTestSubject();
+		boolean shouldLimit = testSubject.shouldLimitRange(BigInteger.TEN, BigInteger.TEN.add(BigInteger.valueOf(RetrieveConfig.DEFAULT_MAX_SERVER_SIDE_ENTRIES + 1)));
+		assertTrue(shouldLimit);
+	}
+
+	@Test
+	public void testLimitEndPositionShouldNotLimitExactLimit() throws Exception {
+		RetrieveJournal testSubject = createTestSubject();
+		boolean shouldLimit = testSubject.shouldLimitRange(BigInteger.TEN, BigInteger.TEN.add(BigInteger.valueOf(RetrieveConfig.DEFAULT_MAX_SERVER_SIDE_ENTRIES)));
+		assertFalse(shouldLimit);
+	}
+
+	@Test
+	public void testLimitEndPositionShouldNotLimit() throws Exception {
+		RetrieveJournal testSubject = createTestSubject();
+		boolean shouldLimit = testSubject.shouldLimitRange(BigInteger.TEN, BigInteger.valueOf(RetrieveConfig.DEFAULT_MAX_SERVER_SIDE_ENTRIES));
+		assertFalse(shouldLimit);
+	}
+	
+	@Test
+	public void testJournalAtMaxOffsetInMiddle() throws Exception {
+		RetrieveJournal testSubject = createTestSubject();
+		long size = 2*RetrieveConfig.DEFAULT_MAX_SERVER_SIDE_ENTRIES/3;
+		List<DetailedJournalReceiver> receivers = createReceiversFixedSequence(size);
+		BigInteger currentOffset = BigInteger.valueOf(size*4);
+		Optional<JournalPosition> found = testSubject.journalAtMaxOffset(new JournalPosition(currentOffset, "receiver", "lib", true), receivers);
+		BigInteger maxOffset = currentOffset.add(BigInteger.valueOf(testSubject.config.maxServerSideEntries()));
+		assertEquals(found, Optional.of(new JournalPosition(maxOffset, "name5", "lib", true)));
+	}
+
+
+	@Test
+	public void testJournalAtMaxOffsetBoundries() throws Exception {
+		RetrieveJournal testSubject = createTestSubject();
+		List<DetailedJournalReceiver> receivers = new ArrayList<>();
+		long size = RetrieveConfig.DEFAULT_MAX_SERVER_SIDE_ENTRIES;
+		for (int i=0; i<10; i++) {
+			BigInteger start = BigInteger.valueOf(i*size + 1);
+			BigInteger end = BigInteger.valueOf((i+1)*size);
+			DetailedJournalReceiver j = new DetailedJournalReceiver(new JournalReceiverInfo("name"+i, "lib", new Date(), JournalStatus.Attached, Optional.<Integer>empty()), start, end, "next", "nextDual", 100, 10000);
+			System.out.println(j);
+			receivers.add(j);
+		}
+		BigInteger startOffset = BigInteger.valueOf(RetrieveConfig.DEFAULT_MAX_SERVER_SIDE_ENTRIES*2);
+		Optional<JournalPosition> foundStart = testSubject.journalAtMaxOffset(new JournalPosition(startOffset, "receiver", "lib", true), receivers);
+		BigInteger maxStartOffset = startOffset.add(BigInteger.valueOf(testSubject.config.maxServerSideEntries()));
+		assertEquals(foundStart, Optional.of(new JournalPosition(maxStartOffset, "name2", "lib", true)));
+
+		BigInteger endOffset = BigInteger.valueOf(RetrieveConfig.DEFAULT_MAX_SERVER_SIDE_ENTRIES*4-1);
+		Optional<JournalPosition> foundEnd = testSubject.journalAtMaxOffset(new JournalPosition(endOffset, "receiver", "lib", true), receivers);
+		BigInteger maxEndOffset = endOffset.add(BigInteger.valueOf(testSubject.config.maxServerSideEntries()));
+		assertEquals(foundEnd, Optional.of(new JournalPosition(maxEndOffset, "name4", "lib", true)));
+	}
+	
+
+	private List<DetailedJournalReceiver> createReceiversFixedSequence(long size) {
+		List<DetailedJournalReceiver> receivers = new ArrayList<>();
+		for (int i=0; i<10; i++) {
+			BigInteger start = BigInteger.valueOf(i*size + 1);
+			BigInteger end = BigInteger.valueOf((i+1)*size);
+			DetailedJournalReceiver j = new DetailedJournalReceiver(new JournalReceiverInfo("name"+i, "lib", new Date(), JournalStatus.Attached, Optional.<Integer>empty()), start, end, "next", "nextDual", 100, 10000);
+			System.out.println(j);
+			receivers.add(j);
+		}
+		return receivers;
+	}
+}


### PR DESCRIPTION
To prevent timeouts we limit how bug offset is we ask for is
However we failed to also set the receiver to the right value but left it on the original receiver
Asking for journal entries when the receiver has been deleted causes an error so we need to make sure we keep up with the receiver names