### PR TITLE
IBM i exit program

### DIFF
--- a/ibmi-exit-pgm/README.md
+++ b/ibmi-exit-pgm/README.md
@@ -1,0 +1,50 @@
+# Debezium Connector for Db2 for i - Exit Program
+
+This is a utility for the [Db2 for i Dezebium Connector](https://github.com/jhc-systems/debezium-connector-ibmi) project.
+
+The connector reads the IBM i journal and relays this information to Kafka. If a journal receiver were to be removed before the connector has fully processed, however, journal entries would be missed and data loss would occur.
+
+IBM i has a facility to prevent journal receivers being deleted. We can register a program as an [Exit Program](https://www.ibm.com/docs/en/i/7.5?topic=concepts-exit-programs) and the system will call it to confirm whether a deletion command for a journal receiver may proceed.
+
+## Deployment
+
+The exit program and associated database must deployed into the same library. The exit program will only ever check the database tables in the same library that contains it.
+
+Beyond that restrictions, you may deploy it multiple times on your system if you wish. Just register an exit program for each instance, and they will ensure that journal receivers are not deleted prematurely.
+
+Follow one of the two options below to either build the objects from source, or deploy from a save file.
+
+### Building from source
+
+You must have `git` installed on your system. If you have not done so, please follow the instructions at http://ibm.biz/ibmi-rpms
+
+Open a shell (SSH preferred, but QShell should also work). Change to a suitable working directory and clone this repository to your IBM i:
+
+    cd $HOME
+    /QOpenSys/pkgs/bin/git clone https://github.com/jhc-systems/debezium-connector-ibmi-exit-pgm
+    cd debezium-connector-ibmi-exit-pgm
+
+There are two shell scripts to build the project. As an argument to each, pass the name of the library where you would like the objects to be deployed:
+
+    ./builddb.sh DEBEZIUM
+    ./buildpgm.sh DEBEZIUM
+
+NOTE: If the database library already exists, perform a back up prior to building, as the build process may cause data loss of registered connectors and processed journal receivers.
+
+### From save file
+
+TODO
+
+## Authorities
+
+For security, review the authorities of the DEBEXIT program to ensure that unauthorised users cannot replace the program with custom code.
+
+Review the authorities for the database objects created and ensure these are sufficient to allow the user(s) running the Debezium connector to be able to write data to the tables.
+
+## Registration
+
+With the database and exit program deployed in the library of your choice, you must register the exit program with the system.
+
+Enter the following command, replacing `mylib` in the `PGM` argument as appropriate:
+
+    ADDEXITPGM EXITPNT(QIBM_QJO_DLT_JRNRCV) FORMAT(DRCV0100) PGMNBR(*LOW) PGM(mylib/DEBEXIT)

--- a/ibmi-exit-pgm/addexitpgm.sh
+++ b/ibmi-exit-pgm/addexitpgm.sh
@@ -1,0 +1,14 @@
+#!/QOpenSys/pkgs/bin/bash
+
+set -exuo pipefail
+
+if [ $# -lt 1 -o $# -gt 2 ]; then
+    echo "Usage: $0 LIBRARY [DATA_LIBRARY]"
+    echo "  e.g. $0 DEBEZIUM"
+    echo "  e.g. $0 DEBEZIUM MYDATABASE"
+    exit 1
+fi
+
+library="${1^^}"
+
+system "ADDEXITPGM EXITPNT(QIBM_QJO_DLT_JRNRCV) FORMAT(DRCV0100) PGMNBR(*LOW) PGM($library/DEBEXIT) THDSAFE(*YES)"

--- a/ibmi-exit-pgm/builddb.sh
+++ b/ibmi-exit-pgm/builddb.sh
@@ -1,0 +1,31 @@
+#!/QOpenSys/pkgs/bin/bash
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 LIBRARY"
+    echo "  e.g. $0 DEBEZIUM"
+    exit 1
+fi
+
+target_lib="${1%% }"
+lib_path="/QSYS.LIB/$1.LIB"
+repo_base=`dirname $0`
+tgtrls="*CURRENT"
+
+if [[ ! -d  "$lib_path" ]]; then
+    echo "Library $1 does not exist. Creating..."
+    /QOpenSys/usr/bin/db2 "CREATE SCHEMA $target_lib"
+    echo "Library $1 created."
+fi
+
+target_pgm="$target_lib/DEBEXIT"
+
+echo "Creating tables in library ${target_lib}..."
+
+build_cmd="RUNSQLSTM SRCSTMF('$repo_base/src/database.sql') COMMIT(*NONE) TGTRLS($tgtrls)"
+
+liblist -c "$target_lib"
+cl -S "$build_cmd"
+
+echo "Database created."

--- a/ibmi-exit-pgm/buildpgm.sh
+++ b/ibmi-exit-pgm/buildpgm.sh
@@ -1,0 +1,30 @@
+#!/QOpenSys/pkgs/bin/bash
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 LIBRARY"
+    echo "  e.g. $0 DEBEZIUM"
+    exit 1
+fi
+
+target_lib="${1%% }"
+lib_path="/QSYS.LIB/$1.LIB"
+repo_base=`dirname $0`
+tgtrls="*CURRENT"
+
+if [[ ! -d  "$lib_path" ]]; then
+    echo "Library $1 does not exist. Creating..."
+    /QOpenSys/usr/bin/db2 "CREATE SCHEMA $target_lib"
+    echo "Library $1 created."
+fi
+
+target_pgm="$target_lib/DEBEXIT"
+
+echo "Creating program $target_pgm..."
+
+build_cmd="CRTSQLRPGI OBJ($target_pgm) SRCSTMF('$repo_base/src/debexit.sqlrpgle') TGTRLS($tgtrls) COMPILEOPT('TGTCCSID(*JOB)') RPGPPOPT(*LVL2)  DBGVIEW(*SOURCE)"
+
+cl -S "$build_cmd" > /dev/null || cl -S "$build_cmd OUTPUT(*PRINT)"  # Second attempt will give compiler listing
+
+echo "Program created."

--- a/ibmi-exit-pgm/package.sh
+++ b/ibmi-exit-pgm/package.sh
@@ -1,0 +1,4 @@
+#!/QOpenSys/pkgs/bin/bash
+
+# TODO - This script should create a save file that we can add to Github releases
+exit 0

--- a/ibmi-exit-pgm/runtest.sh
+++ b/ibmi-exit-pgm/runtest.sh
@@ -1,0 +1,30 @@
+#!/QOpenSys/pkgs/bin/bash
+
+set -euo pipefail
+
+test_lib=TSTDEBEXIT
+lib_path="/QSYS.LIB/$test_lib.LIB"
+repo_base=`dirname $0`
+tgtrls="*CURRENT"
+
+if [[ ! -d  "$lib_path" ]]; then
+    echo "Library $test_lib does not exist. Setting up..."
+    ${repo_base}/builddb.sh TSTDEBEXIT
+fi
+
+${repo_base}/buildpgm.sh "$test_lib"
+
+target_pgm="$test_lib/TSTDEBEXIT"
+
+echo "Creating program $target_pgm..."
+
+build_cmd="CRTSQLRPGI OBJ($target_pgm) SRCSTMF('$repo_base/test/tstdebexit.sqlrpgle') TGTRLS($tgtrls) COMPILEOPT('TGTCCSID(*JOB)') RPGPPOPT(*LVL2) DBGVIEW(*SOURCE)"
+
+cl -S "$build_cmd" > /dev/null || cl -S "$build_cmd OUTPUT(*PRINT)"  # Second attempt will give compiler listing
+
+echo "Test program created. Executing..."
+
+liblist -c "$test_lib"
+cl "CALL TSTDEBEXIT"
+
+echo "Test finished successfully."

--- a/ibmi-exit-pgm/src/database.sql
+++ b/ibmi-exit-pgm/src/database.sql
@@ -1,0 +1,45 @@
+CREATE OR REPLACE TABLE debezium_connector
+FOR SYSTEM NAME debconnect 
+(
+    CONSTRAINT pk_debezium_connector
+    PRIMARY KEY (connector_id),
+    
+    connector_id FOR COLUMN id INT NOT NULL,
+    connector_name FOR COLUMN connname VARCHAR(100) NOT NULL,
+    journal_name FOR COLUMN jrnnam CHAR(10) NOT NULL,
+    journal_library FOR COLUMN jrnlib CHAR(10) NOT NULL,
+    deleted TIMESTAMP
+);
+
+
+DROP INDEX IF EXISTS debezium_connector_01;
+
+CREATE INDEX debezium_connector_01
+FOR SYSTEM NAME debconnec1
+ON debezium_connector (journal_library, journal_name);
+
+
+CREATE OR REPLACE TABLE debezium_processed_receiver
+FOR SYSTEM NAME debprcrcv
+(
+    CONSTRAINT pk_debezium_processed_receiver
+    PRIMARY KEY (connector_id, receiver_name, receiver_library),
+        
+    connector_id FOR COLUMN id INT NOT NULL,
+    receiver_name FOR COLUMN jrnrcvnam CHAR(10) NOT NULL,
+    receiver_library FOR COLUMN jrnrcvlib CHAR(10) NOT NULL,
+    completed TIMESTAMP NOT NULL
+        DEFAULT CURRENT TIMESTAMP,
+    
+    CONSTRAINT fk_debezium_connector_debezium_processed_receiver
+    FOREIGN KEY (connector_id) REFERENCES debezium_connector (connector_id)
+    ON UPDATE RESTRICT
+    ON DELETE CASCADE
+);
+
+
+DROP INDEX IF EXISTS debezium_processed_receiver_01;
+
+CREATE INDEX debezium_processed_receiver_01
+FOR SYSTEM NAME debprcrcv1
+ON debezium_processed_receiver (receiver_library, receiver_name);

--- a/ibmi-exit-pgm/src/debexit.rpgleinc
+++ b/ibmi-exit-pgm/src/debexit.rpgleinc
@@ -1,0 +1,8 @@
+**free
+
+/include ./exit_pgm_defs.rpgleinc
+
+dcl-pr debexit extpgm;
+  exitInfo likeds(t_DRCV0100) const;
+  statusInfo likeds(t_dltjrnrcvStatus);
+end-pr;

--- a/ibmi-exit-pgm/src/debexit.sqlrpgle
+++ b/ibmi-exit-pgm/src/debexit.sqlrpgle
@@ -1,0 +1,89 @@
+**free
+
+ctl-opt copyright('Copyright JHC Systems 2023')
+        option(*nodebugio: *srcstmt)
+        thread(*concurrent)
+        actgrp('DEBEZIUM')
+        main(debexit);
+
+exec sql
+  SET OPTION commit = *none;
+
+/include ./debexit.rpgleinc
+
+
+dcl-ds psds qualified psds;
+  programLibrary char(10) pos(81);
+end-ds;
+
+
+dcl-proc debexit;
+  dcl-pi *n;
+    exitInfo likeds(t_DRCV0100) const; 
+    statusInfo likeds(t_dltjrnrcvStatus);
+  end-pi;
+
+  statusInfo.length = %size(t_dltjrnrcvStatus);
+  statusInfo.deleteStatus = PREVENT_DELETION;
+
+  if isReceiverRequired(
+    psds.programLibrary :
+    exitInfo.journalReceiver :
+    exitInfo.journalReceiverLibrary :
+    exitInfo.journal :
+    exitInfo.journalLibrary
+  );
+    return;
+  endif;
+
+  statusInfo.deleteStatus = PERMIT_DELETION;
+end-proc;
+
+
+dcl-proc isReceiverRequired;
+  dcl-pi *n ind;
+    registryLibrary varchar(10) const;
+    receiverName char(10) value;
+    receiverLibrary char(10) value;
+    journalName char(10) value;
+    journalLibrary char(10) value;
+  end-pi;
+
+  dcl-s statement varchar(1000);
+  dcl-s preparedLibrary char(10) static;
+  dcl-s found char(1);
+  dcl-s nullInd int(5);
+
+  if preparedLibrary <> registryLibrary;
+    statement = 'VALUES (  -
+                  SELECT ''Y''  -
+                  FROM ' + %trimr(registryLibrary) + '/debezium_connector AS c  -
+                  WHERE c.journal_name = ?  -
+                    AND c.journal_library = ?  -
+                    AND c.deleted IS NULL  -
+                    AND c.connector_id NOT IN (  -
+                      SELECT connector_id  -
+                      FROM ' + %trimr(registryLibrary) + '/debezium_processed_receiver AS p  -
+                      WHERE p.receiver_name = ?  -
+                        AND p.receiver_library = ?  -
+                  )  -
+                  LIMIT 1  -
+                ) INTO ?';
+
+    exec sql
+      PREPARE unprocessed_receivers FROM :statement;
+
+    preparedLibrary = registryLibrary;
+  endif;
+
+  exec sql
+    EXECUTE unprocessed_receivers
+    USING
+      :journalName,
+      :journalLibrary,
+      :receiverName,
+      :receiverLibrary,
+      :found :nullInd;
+  
+  return (SQLSTATE = '00000' and nullInd = 0);
+end-proc;

--- a/ibmi-exit-pgm/src/exit_pgm_defs.rpgleinc
+++ b/ibmi-exit-pgm/src/exit_pgm_defs.rpgleinc
@@ -1,0 +1,27 @@
+**free
+
+dcl-ds t_DRCV0100 qualified template;
+  length int(10);
+  exitPointName char(20);
+  exitPointFormat char(8);
+  journalReceiver char(10);
+  journalReceiverLibrary char(10);
+  journal char(10);
+  journalLibrary char(10);
+  calledBySystemJob char(1);
+  calledDuringIpl char(1);
+  calledDuringProcessEnd char(1);
+  journalType char(1);
+  remoteJournalType char(1);
+  saveStatus char(1);
+  partialStatus char(1);
+  detachedDateAndTime char(13);
+end-ds;
+
+dcl-c PERMIT_DELETION '1';
+dcl-c PREVENT_DELETION '0';
+
+dcl-ds t_dltjrnrcvStatus qualified template;
+  length int(10);
+  deleteStatus char(1) inz(PREVENT_DELETION);
+end-ds;

--- a/ibmi-exit-pgm/test/tstdebexit.sqlrpgle
+++ b/ibmi-exit-pgm/test/tstdebexit.sqlrpgle
@@ -1,0 +1,78 @@
+**free
+
+// A very rudimentary test. Relies on the database and exit program being deployed
+// to library TSTDEBEXIT.
+
+ctl-opt copyright('Copyright JHC Systems 2023')
+        option(*nodebugio: *srcstmt)
+        thread(*concurrent)
+        actgrp(*new)
+        main(main);
+
+exec sql
+  SET OPTION commit = *none;
+
+/include ../src/debexit.rpgleinc
+
+
+dcl-proc main;
+  exec sql
+    DELETE FROM tstdebexit.debezium_connector;
+ 
+  exec sql
+    INSERT INTO tstdebexit.debezium_connector
+      (connector_id, connector_name, journal_name, journal_library, deleted)
+    VALUES
+      (1, 'Connector 1', 'JRN_A', 'JRNLIB', NULL),
+      (2, 'Connector 2', 'JRN_B', 'JRNLIB', CURRENT TIMESTAMP),
+      (3, 'Connector 3', 'JRN_C', 'JRNLIB', NULL),
+      (4, 'Connector 4', 'JRN_C', 'JRNLIB', NULL);
+    
+  exec sql
+    INSERT INTO tstdebexit.debezium_processed_receiver
+      (connector_id, receiver_name, receiver_library)
+    VALUES
+      (3, 'RCV_C1', 'JRNLIB'),
+      (3, 'RCV_C2', 'JRNLIB'),
+      (4, 'RCV_C2', 'JRNLIB');
+
+
+  snd-msg 'No connector monitoring the journal = permitted';
+  testResult('JRN_Z' : 'JRNLIB' : 'RCV_Z1' : 'JRNLIB' : PERMIT_DELETION);
+
+  snd-msg 'No record of the receiver for the monitored journal = denied';
+  testResult('JRN_A' : 'JRNLIB' : 'RCV_A1' : 'JRNLIB' : PREVENT_DELETION);
+
+  snd-msg 'A deleted connector does not prevent deletion';
+  testResult('JRN_B' : 'JRNLIB' : 'RCV_B1' : 'JRNLIB' : PERMIT_DELETION);
+
+  snd-msg 'A receiver must have been processed by all monitoring connectors';
+  testResult('JRN_C' : 'JRNLIB' : 'RCV_C1' : 'JRNLIB' : PREVENT_DELETION);
+  testResult('JRN_C' : 'JRNLIB' : 'RCV_C2' : 'JRNLIB' : PERMIT_DELETION);
+end-proc;
+
+
+dcl-proc testResult;
+  dcl-pi *n;
+    journalName varchar(10) const;
+    journalLibrary varchar(10) const;
+    receiverName varchar(10) const;
+    receiverLibrary varchar(10) const;
+    expectedResult varchar(1) const;
+  end-pi;
+
+  dcl-ds exitInfo likeds(t_DRCV0100);
+  dcl-ds statusInfo likeds(t_dltjrnrcvStatus);
+
+  exitInfo.journalReceiver = receiverName;
+  exitInfo.journalReceiverLibrary = receiverLibrary;
+  exitInfo.journal = journalName;
+  exitInfo.journalLibrary = journalLibrary;
+
+  debexit(exitInfo : statusInfo);
+
+  if expectedResult <> statusInfo.deleteStatus;
+    snd-msg *escape 'Failed on jrn ' + journalLibrary + '/' + journalName + ',' +
+      ' rcv ' + receiverLibrary + '/' + receiverName;
+  endif;
+end-proc;


### PR DESCRIPTION
This exit program can be registered with the system to avoid premature deletion of journal receivers, before the connector has had a chance to fully process them.

This needs the corresponding connector changes to maintain the new tables before we merge this, but I'm creating the review now for visibility.