### PR TITLE
smt to make sinking topics on mass easier

### DIFF
--- a/kafka-smt-collection/src/main/java/com/fnz/kakfa/smt/LowerCaseTopicRePrefixSink.java
+++ b/kafka-smt-collection/src/main/java/com/fnz/kakfa/smt/LowerCaseTopicRePrefixSink.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.fnz.kakfa.smt;
+
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fnz.kakfa.smt.RepackageJavaFriendlySchemaRenamer.SimpleConfig;
+
+public class LowerCaseTopicRePrefixSink<R extends ConnectRecord<R>> implements Transformation<R> {
+	private static final Logger log = LoggerFactory.getLogger(LowerCaseTopicRePrefixSink.class);
+
+	public static final String OVERVIEW_DOC = "<p/>lowercase topic, replace prefix</p>";
+
+	public static final String PREFIX = "prefix";
+
+	public static final ConfigDef CONFIG_DEF = new ConfigDef().define(PREFIX, ConfigDef.Type.STRING,
+			ConfigDef.NO_DEFAULT_VALUE, new ConfigDef.Validator() {
+		@Override
+		public void ensureValid(String name, Object valueObject) {
+			final String value = (String) valueObject;
+			if (value == null || value.isEmpty()) {
+				throw new ConfigException("Must specify replacement e.g. 'schema'");
+			}
+		}
+
+		@Override
+		public String toString() {
+			return "Replacement string";
+		}
+	}, ConfigDef.Importance.HIGH, "replace topic prefix with schema for sink");
+
+	private static final String PURPOSE = "rename to schemas";
+
+	private String prefix;
+
+	@Override
+	public void configure(Map<String, ?> props) {
+		final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
+		prefix = String.format("%s", config.getString(PREFIX));
+	}
+
+	@Override
+	public R apply(R record) {
+		String topic = record.topic();
+		final int pos = topic.lastIndexOf(".");
+		if (pos >= 0 && ((pos + 1) <= topic.length())) {
+			topic = topic.substring(pos + 1);
+		}
+		topic = String.format("%s.%s", prefix, topic.toLowerCase());
+		return record.newRecord(topic, record.kafkaPartition(), record.keySchema(), record.key(), record.valueSchema(),
+				record.value(), record.timestamp());
+	}
+
+	@Override
+	public void close() {
+	}
+
+	@Override
+	public ConfigDef config() {
+		return CONFIG_DEF;
+	}
+}

--- a/kafka-smt-collection/src/test/java/com/fnz/kakfa/smt/LowerCaseTopicRePrefixSinkTest.java
+++ b/kafka-smt-collection/src/test/java/com/fnz/kakfa/smt/LowerCaseTopicRePrefixSinkTest.java
@@ -1,0 +1,60 @@
+package com.fnz.kakfa.smt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class LowerCaseTopicRePrefixSinkTest {
+	LowerCaseTopicRePrefixSink<SourceRecord> lct = new LowerCaseTopicRePrefixSink<>();
+	Schema schema;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		final SchemaBuilder sb = new SchemaBuilder(Type.STRING);
+		schema = sb.build();
+
+		final Map<String, String> m = Map.of("prefix", "myschema");
+		lct.configure(m);
+	}
+
+	@Test
+	void testNormalString() {
+		final Map<String, Integer> sourcePartition = new HashMap<>();
+		final Map<String, Integer> sourceOffset = new HashMap<>();
+		final SourceRecord r = new SourceRecord(sourcePartition, sourceOffset, "FOO.BAR.TOPIC", 1, schema, "key",
+				schema, "value", 1l);
+		final SourceRecord lowered = lct.apply(r);
+
+		assertEquals("myschema.topic", lowered.topic());
+	}
+
+	@Test
+	void testNoPrefix() {
+		final Map<String, Integer> sourcePartition = new HashMap<>();
+		final Map<String, Integer> sourceOffset = new HashMap<>();
+		final SourceRecord r = new SourceRecord(sourcePartition, sourceOffset, "TOPIC", 1, schema, "key", schema,
+				"value", 1l);
+		final SourceRecord lowered = lct.apply(r);
+
+		assertEquals("myschema.topic", lowered.topic());
+	}
+
+	@Test
+	void testEndsWithDot() {
+		final Map<String, Integer> sourcePartition = new HashMap<>();
+		final Map<String, Integer> sourceOffset = new HashMap<>();
+		final SourceRecord r = new SourceRecord(sourcePartition, sourceOffset, "TOPIC.", 1, schema, "key", schema,
+				"value", 1l);
+		final SourceRecord lowered = lct.apply(r);
+
+		assertEquals("myschema.", lowered.topic());
+	}
+}


### PR DESCRIPTION
for topics named db.company.com.schema.table I want to sink to newschema.table
connector config:
```
    "topics.regex": "db.company.*",
    "transforms": "unwrap,ToLower,ToLowerSink",
    "transforms.unwrap.drop.tombstones": "false",
    "transforms.unwrap.type": "io.debezium.transforms.ExtractNewRecordState",
    "transforms.ToLowerSink.type": "com.fnz.kakfa.smt.LowerCaseTopicRePrefixSink",
    "transforms.ToLowerSink.prefix": "public",
```
I was tempted to combine the two, tolower transforms and it is probably worth doing.