### PR TITLE
V3.3.0 fnz cache delay

### DIFF
--- a/debezium-connector-ibmi/pom.xml
+++ b/debezium-connector-ibmi/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-reactor-ibmi</artifactId>
-        <version>3.3.1.Final_FNZ1</version>
+        <version>3.3.1.Final_FNZ2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-ibmi/pom.xml
+++ b/debezium-connector-ibmi/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-reactor-ibmi</artifactId>
-        <version>3.3.0.Final_FNZ1</version>
+        <version>3.3.1.Final_FNZ1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
@@ -105,6 +105,11 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
     public static final Field MAX_RETRIEVAL_TIMEOUT = Field.create("max.journal.timeout", "max time to fetch the journal entries",
             "Maximum time to fetch the journal entries in ms", DEFAULT_MAX_JOURNAL_TIMEOUT);
 
+    public static final long DEFAULT_CACHE_ADDITIONAL_DELAY = 5000;
+
+    public static final Field JOURNAL_CACHE_ADDITIONAL_DELAY = Field.create("journal.additional.delay", "additional delay when journal caching is enabled",
+            "additional journal cache delay in ms used when journal caching is enabled", DEFAULT_CACHE_ADDITIONAL_DELAY);
+
     public static final Field TOPIC_NAMING_STRATEGY = Field.create("topic.naming.strategy")
             .withDisplayName("Topic naming strategy class")
             .withType(Type.CLASS)
@@ -187,6 +192,10 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
         return config.getString(DIAGNOSTICS_FOLDER);
     }
 
+    public Long cacheAdditionalDelay() {
+        return config.getLong(JOURNAL_CACHE_ADDITIONAL_DELAY);
+    }
+
     public JournalProcessedPosition getOffset() {
         final String receiver = config.getString(As400OffsetContext.RECEIVER);
         final String lib = config.getString(As400OffsetContext.RECEIVER_LIBRARY);
@@ -223,7 +232,7 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
     public static Field.Set ALL_FIELDS = Field.setOf(JdbcConfiguration.HOSTNAME, USER, PASSWORD, SCHEMA, BUFFER_SIZE,
             RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE, SOCKET_TIMEOUT,
             MAX_SERVER_SIDE_ENTRIES, TOPIC_NAMING_STRATEGY, FROM_CCSID, TO_CCSID, SECURE,
-            DIAGNOSTICS_FOLDER);
+            DIAGNOSTICS_FOLDER, JOURNAL_CACHE_ADDITIONAL_DELAY);
 
     public static ConfigDef configDef() {
         final ConfigDef c = RelationalDatabaseConnectorConfig.CONFIG_DEFINITION.edit()
@@ -231,7 +240,7 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
                 .type(
                         HOSTNAME, USER, PASSWORD, SCHEMA, BUFFER_SIZE,
                         SOCKET_TIMEOUT, FROM_CCSID, TO_CCSID, SECURE,
-                        DIAGNOSTICS_FOLDER)
+                        DIAGNOSTICS_FOLDER, JOURNAL_CACHE_ADDITIONAL_DELAY)
                 .connector(
                         SCHEMA_NAME_ADJUSTMENT_MODE)
                 .events(

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorTask.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorTask.java
@@ -26,6 +26,7 @@ import io.debezium.connector.db2as400.metrics.As400ChangeEventSourceMetricsFacto
 import io.debezium.connector.db2as400.metrics.As400StreamingChangeEventSourceMetrics;
 import io.debezium.document.DocumentReader;
 import io.debezium.ibmi.db2.journal.retrieve.FileFilter;
+import io.debezium.ibmi.db2.journal.retrieve.JournalInfoRetrieval;
 import io.debezium.jdbc.DefaultMainConnectionProvidingConnectionFactory;
 import io.debezium.jdbc.MainConnectionProvidingConnectionFactory;
 import io.debezium.pipeline.ChangeEventSourceCoordinator;
@@ -122,8 +123,10 @@ public class As400ConnectorTask extends BaseSourceTask<As400Partition, As400Offs
         final List<FileFilter> shortIncludes = jdbcConnection.shortIncludes(schema.getSchemaName(),
                 configuredIncludes);
 
+        final long cacheWait = JournalInfoRetrieval.getJournalCacheDurationInMilliseconds(jdbcConnection);
+
         final As400RpcConnection rpcConnection = new As400RpcConnection(connectorConfig, streamingMetrics,
-                shortIncludes);
+                shortIncludes, cacheWait);
 
         validateSchemaHistory(connectorConfig, rpcConnection::validateLogPosition, previousOffsetPartition, schema,
                 snapshotterService.getSnapshotter());

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
@@ -59,7 +59,7 @@ public class As400RpcConnection implements AutoCloseable, Connect<AS400, IOExcep
         this.config = config;
         this.isSecure = config.getJdbcConfig().getBoolean("secure", config.isSecure());
         this.streamingMetrics = streamingMetrics;
-        this.journalInfoRetrieval = new JournalInfoRetrieval(cacheWait, config.getPollInterval().toMillis());
+        this.journalInfoRetrieval = new JournalInfoRetrieval(cacheWait, config.cacheAdditionalDelay(), config.getPollInterval().toMillis());
         try {
             System.setProperty("com.ibm.as400.access.AS400.guiAvailable", "False");
             journalInfo = journalInfoRetrieval.getJournal(connection(), config.getSchema(), includes);
@@ -70,8 +70,6 @@ public class As400RpcConnection implements AutoCloseable, Connect<AS400, IOExcep
                     .withMaxServerSideEntries(config.getMaxServerSideEntries())
                     .withServerFiltering(true)
                     .withIncludeFiles(includes).withDumpFolder(config.diagnosticsFolder())
-                    .withJournalCacheDelay(cacheWait + config.cacheAdditionalDelay())
-                    .withPollInterval(config.getPollInterval().toMillis())
                     .build();
             retrieveJournal = new RetrieveJournal(rconfig, journalInfoRetrieval);
         }

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSource.java
@@ -115,7 +115,7 @@ public class As400SnapshotChangeEventSource
                                            RelationalSnapshotContext<As400Partition, As400OffsetContext> snapshotContext,
                                            As400OffsetContext previousOffset)
             throws Exception {
-        if (previousOffset != null && previousOffset.isPositionSet() && snapshotterService.getSnapshotter().shouldStreamEventsStartingFromSnapshot()) {
+        if (previousOffset != null && previousOffset.isPositionSet()) {
             snapshotContext.offset = previousOffset;
         }
         else {
@@ -198,23 +198,9 @@ public class As400SnapshotChangeEventSource
         final List<String> dataCollectionsToBeSnapshotted = connectorConfig.getDataCollectionsToBeSnapshotted();
         final Map<DataCollectionId, String> snapshotSelectOverridesByTable = connectorConfig.getSnapshotSelectOverridesByTable();
 
+
         boolean offsetExists = previousOffset != null;
-        boolean snapshotInProgress = false;
-
-        if (offsetExists) {
-            snapshotInProgress = !previousOffset.isSnapshotComplete();
-        }
-
-        if (offsetExists && previousOffset.isSnapshotComplete()) {
-            // when control tables in place
-            if (!previousOffset.hasNewTables()) {
-                log.info(
-                        "A previous offset indicating a completed snapshot has been found. Neither schema nor data will be snapshotted.");
-                return new SnapshottingTask(true, false, dataCollectionsToBeSnapshotted,
-                        snapshotSelectOverridesByTable, false);
-            }
-            log.info("A previous offset indicating a completed snapshot has been found.");
-        }
+        boolean snapshotInProgress = (offsetExists && previousOffset.isInitialSnapshotRunning());
 
         boolean shouldSnapshotSchema = snapshotter.shouldSnapshotSchema(offsetExists, snapshotInProgress);
         boolean shouldSnapshotData = snapshotter.shouldSnapshotData(offsetExists, snapshotInProgress);

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSource.java
@@ -115,7 +115,7 @@ public class As400SnapshotChangeEventSource
                                            RelationalSnapshotContext<As400Partition, As400OffsetContext> snapshotContext,
                                            As400OffsetContext previousOffset)
             throws Exception {
-        if (previousOffset != null && previousOffset.isPositionSet() && !snapshotterService.getSnapshotter().shouldStreamEventsStartingFromSnapshot()) {
+        if (previousOffset != null && previousOffset.isPositionSet() && snapshotterService.getSnapshotter().shouldStreamEventsStartingFromSnapshot()) {
             snapshotContext.offset = previousOffset;
         }
         else {

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
@@ -123,6 +123,8 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
                     try {
                         switch (dataConnection.getJournalEntries(context, offsetContext,
                                 processJournalEntries(partition, offsetContext), watchDog)) {
+                            case Success:
+                                break;
                             case MoreDataAvailable:
                                 break;
                             case NotCalled:
@@ -135,11 +137,12 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
                         }
                         retries = 0;
                     }
+                    catch (final InvalidPositionException e) {
+                        throw new DebeziumException("Invalid journal receiver/sequence are we using the wrong offset for the receiver: " + offsetContext.getPosition(),
+                                e);
+                    }
                     catch (final FatalException e) {
                         throw new DebeziumException("Unable to process offset " + offsetContext.getPosition(), e);
-                    }
-                    catch (final InvalidPositionException e) {
-                        throw new DebeziumException("Invalid journal receiver/sequence has the receiver been deleted? position was: " + offsetContext.getPosition(), e);
                     }
                     catch (final InterruptedException e) {
                         if (context.isRunning()) {

--- a/journal-parsing/pom.xml
+++ b/journal-parsing/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-reactor-ibmi</artifactId>
-        <version>3.3.0.Final_FNZ1</version>
+        <version>3.3.1.Final_FNZ1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/journal-parsing/pom.xml
+++ b/journal-parsing/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-reactor-ibmi</artifactId>
-        <version>3.3.1.Final_FNZ1</version>
+        <version>3.3.1.Final_FNZ2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/DelayedDetailedJournalReceiver.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/DelayedDetailedJournalReceiver.java
@@ -28,13 +28,15 @@ public class DelayedDetailedJournalReceiver {
     private long minDelayBetweenReadings;
     private long delayMs;
     private final Supplier<Long> timeSupplier;
+    static final double TIMING_ALLOWANCE_PERCENT = 20.0;
+    static final double TIMING_ALLOWANCE_RATIO = TIMING_ALLOWANCE_PERCENT / 100.0;
 
     public DelayedDetailedJournalReceiver(long delayMs, long pollIntervalMs) {
         this(delayMs, pollIntervalMs, System::currentTimeMillis);
     }
 
     public DelayedDetailedJournalReceiver(long delayMs, long pollIntervalMs, Supplier<Long> timeSupplier) {
-        int t = (int) ((delayMs / pollIntervalMs) * 1.2 + 1); // allow 20% and round up
+        int t = (int) ((delayMs / pollIntervalMs) * (1.0 + TIMING_ALLOWANCE_PERCENT) + 1); // allow 20% and round up
         if (t > MAX_ENTRIES) {
             t = MAX_ENTRIES;
         }
@@ -47,7 +49,7 @@ public class DelayedDetailedJournalReceiver {
 
     public void addDetailedReceiver(DetailedJournalReceiver position) {
         long now = timeSupplier.get();
-        if (now < minDelayBetweenReadings + lastAdded) {
+        if (now < minDelayBetweenReadings + lastAdded - (minDelayBetweenReadings * TIMING_ALLOWANCE_PERCENT)) {
             log.debug("not adding as buffer has resolution {} and last added was at {}", minDelayBetweenReadings, lastAdded);
             return;
         }

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/DelayedDetailedJournalReceiver.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/DelayedDetailedJournalReceiver.java
@@ -1,0 +1,77 @@
+package io.debezium.ibmi.db2.journal.retrieve;
+
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.ibmi.db2.journal.retrieve.rnrn0200.DetailedJournalReceiver;
+
+public class DelayedDetailedJournalReceiver {
+    private static final Logger log = LoggerFactory.getLogger(DelayedDetailedJournalReceiver.class);
+
+    record TimedPosition(long timestamp, DetailedJournalReceiver position) {
+    }
+
+    private static final int PADDING = 100;
+    private static final int MAX_ENTRIES = 1000; // assuming 35 seconds 1000 entries allows 350ms granularity
+    private final int entries;
+    private final TimedPosition[] timedPositions;
+    private int addPosition = 0;
+    private int getPosition = 0;
+    private long lastAdded = Long.MIN_VALUE;
+    private long minDelayBetweenReadings;
+    private long delayMilliseconds;
+    private final Supplier<Long> timeSupplier;
+
+    public DelayedDetailedJournalReceiver(long delayMilliseconds, long pollIntervalMs) {
+        this(delayMilliseconds, pollIntervalMs, System::currentTimeMillis);
+    }
+
+    public DelayedDetailedJournalReceiver(long delayMilliseconds, long pollIntervalMs, Supplier<Long> timeSupplier) {
+        int t = (int) ((delayMilliseconds / pollIntervalMs) * 1.2 + 1); // allow 20% and round up
+        if (t > MAX_ENTRIES) {
+            t = MAX_ENTRIES;
+        }
+        entries = t + PADDING;
+        timedPositions = new TimedPosition[entries];
+        minDelayBetweenReadings = delayMilliseconds / entries;
+        this.delayMilliseconds = delayMilliseconds;
+        this.timeSupplier = timeSupplier;
+    }
+
+    public void addDetailedReceiver(DetailedJournalReceiver position) {
+        long now = timeSupplier.get();
+        if (now < minDelayBetweenReadings + lastAdded) {
+            log.debug("not adding as buffer has resolution {} and last added was at {}", minDelayBetweenReadings, lastAdded);
+            return;
+        }
+        lastAdded = now;
+        if (timedPositions[addPosition] != null) {
+            log.warn("adding faster than consuming, skipping");
+        }
+        timedPositions[addPosition] = new TimedPosition(now, position);
+        addPosition = (addPosition + 1) % entries;
+    }
+
+    public DetailedJournalReceiver getDelayedReceiver() {
+        long now = timeSupplier.get();
+        TimedPosition tp = timedPositions[getPosition];
+        if (tp == null) {
+            log.debug("no receivers avaiable");
+            return null;
+        }
+        if (now < tp.timestamp + delayMilliseconds) {
+            log.debug("next receiver is still too recent {} need to wait until {} currently {}", tp.timestamp, tp.timestamp + delayMilliseconds, now);
+            return null;
+        }
+        TimedPosition nextTp = tp;
+        do {
+            timedPositions[getPosition] = null;
+            getPosition = (getPosition + 1) % entries;
+            tp = nextTp;
+            nextTp = timedPositions[getPosition];
+        } while (nextTp != null && now >= nextTp.timestamp + delayMilliseconds);
+        return tp.position;
+    }
+}

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfo.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfo.java
@@ -5,9 +5,9 @@
  */
 package io.debezium.ibmi.db2.journal.retrieve;
 
-public record JournalInfo(String journalName, String journalLibrary) {
+public record JournalInfo(String journalName, String journalLibrary, boolean isCaching) {
 
-    public JournalInfo(String journalName, String journalLibrary) {
+    public JournalInfo(String journalName, String journalLibrary, boolean isCaching) {
         if (journalName == null || journalName.trim().length() == 0 || journalName.trim().length() > 10) {
             throw new IllegalArgumentException("receiver name must not be null and length must be <= to 10.");
         }
@@ -16,10 +16,12 @@ public record JournalInfo(String journalName, String journalLibrary) {
         }
         this.journalName = journalName.trim();
         this.journalLibrary = journalLibrary.trim();
+        this.isCaching = isCaching;
     }
 
     @Override
     public String toString() {
-        return String.format("JournalInfo [journalName=%s, journalLibrary=%s]", journalName, journalLibrary);
+        return String.format("JournalInfo [journalName=%s, journalLibrary=%s, isCaching=%s]", journalName,
+                journalLibrary, isCaching);
     }
 }

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrieval.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrieval.java
@@ -66,11 +66,13 @@ public class JournalInfoRetrieval {
     private Map<String, Boolean> isJournalCaching = new HashMap<>();
     private Map<JournalInfo, DelayedDetailedJournalReceiver> delayedCache = new HashMap<>();
     private final long journalCacheDelay;
+    private final long additionalJournalDelay;
     private final long pollInterval;
 
-    public JournalInfoRetrieval(long journalCacheDelay, long pollInterval) {
+    public JournalInfoRetrieval(long journalCacheDelay, long additionalJournalDelay, long pollInterval) {
         super();
         this.journalCacheDelay = journalCacheDelay;
+        this.additionalJournalDelay = additionalJournalDelay;
         this.pollInterval = pollInterval;
     }
 
@@ -107,9 +109,10 @@ public class JournalInfoRetrieval {
     public Optional<DetailedJournalReceiver> getDelayedDetailedJournalReceiver(AS400 as400, JournalInfo journalLib)
             throws Exception {
         DetailedJournalReceiver dr = getCurrentDetailedJournalReceiver(as400, journalLib);
-        if (journalLib.isCaching()) {
+        long totalDelay = additionalJournalDelay + (journalLib.isCaching() ? journalCacheDelay : 0l);
+        if (totalDelay > 0) {
             if (!delayedCache.containsKey(journalLib)) {
-                DelayedDetailedJournalReceiver ddr = new DelayedDetailedJournalReceiver(journalCacheDelay, pollInterval);
+                DelayedDetailedJournalReceiver ddr = new DelayedDetailedJournalReceiver(totalDelay, pollInterval);
                 delayedCache.put(journalLib, ddr);
             }
             DelayedDetailedJournalReceiver cached = delayedCache.get(journalLib);

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrieval.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrieval.java
@@ -65,9 +65,13 @@ public class JournalInfoRetrieval {
     private final DetailedJournalReceiverCache cache = new DetailedJournalReceiverCache();
     private Map<String, Boolean> isJournalCaching = new HashMap<>();
     private Map<JournalInfo, DelayedDetailedJournalReceiver> delayedCache = new HashMap<>();
+    private final long journalCacheDelay;
+    private final long pollInterval;
 
-    public JournalInfoRetrieval() {
+    public JournalInfoRetrieval(long journalCacheDelay, long pollInterval) {
         super();
+        this.journalCacheDelay = journalCacheDelay;
+        this.pollInterval = pollInterval;
     }
 
     public JournalPosition getCurrentPosition(AS400 as400, JournalInfo journalLib) throws Exception {
@@ -100,12 +104,12 @@ public class JournalInfoRetrieval {
         throw new IllegalStateException("Journal not found");
     }
 
-    public Optional<DetailedJournalReceiver> getDelayedDetailedJournalReceiver(AS400 as400, JournalInfo journalLib, long journalCacheDelay, long pollMilliSeconds)
+    public Optional<DetailedJournalReceiver> getDelayedDetailedJournalReceiver(AS400 as400, JournalInfo journalLib)
             throws Exception {
         DetailedJournalReceiver dr = getCurrentDetailedJournalReceiver(as400, journalLib);
         if (journalLib.isCaching()) {
             if (!delayedCache.containsKey(journalLib)) {
-                DelayedDetailedJournalReceiver ddr = new DelayedDetailedJournalReceiver(journalCacheDelay, pollMilliSeconds);
+                DelayedDetailedJournalReceiver ddr = new DelayedDetailedJournalReceiver(journalCacheDelay, pollInterval);
                 delayedCache.put(journalLib, ddr);
             }
             DelayedDetailedJournalReceiver cached = delayedCache.get(journalLib);

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
@@ -33,11 +33,22 @@ public class ReceiverPagination {
         this.journalInfo = journalInfo;
     }
 
-    PositionRange findRange(AS400 as400, JournalProcessedPosition startPosition) throws Exception {
+    Optional<PositionRange> findRange(AS400 as400, JournalProcessedPosition startPosition) throws Exception {
+        final Optional<DetailedJournalReceiver> endPositionOpt = journalInfoRetrieval.getDelayedDetailedJournalReceiver(as400, journalInfo);
+
+        return endPositionOpt.map(endPosition -> {
+            try {
+                return _findRange(as400, startPosition, endPosition);
+            }
+            catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    PositionRange _findRange(AS400 as400, JournalProcessedPosition startPosition, DetailedJournalReceiver endPosition) throws Exception {
         final BigInteger start = startPosition.getOffset();
         final boolean fromBeginning = !startPosition.isOffsetSet() || start.equals(BigInteger.ZERO);
-
-        final DetailedJournalReceiver endPosition = journalInfoRetrieval.getCurrentDetailedJournalReceiver(as400, journalInfo);
 
         if (cachedEndPosition == null) {
             cachedEndPosition = endPosition;

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/RetreivalState.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/RetreivalState.java
@@ -8,7 +8,6 @@ package io.debezium.ibmi.db2.journal.retrieve;
 public enum RetreivalState {
     Success,
     MoreDataAvailable,
-    LostJournal,
     NotCalled;
 
     public boolean hasData() {

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/RetreivalState.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/RetreivalState.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.ibmi.db2.journal.retrieve;
+
+public enum RetreivalState {
+    Success,
+    MoreDataAvailable,
+    LostJournal,
+    NotCalled;
+
+    public boolean hasData() {
+        return this == Success || this == MoreDataAvailable;
+    }
+}

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/RetrieveConfig.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/RetrieveConfig.java
@@ -15,7 +15,7 @@ import io.debezium.ibmi.db2.journal.retrieve.RetrievalCriteria.JournalCode;
 
 public record RetrieveConfig(Connect<AS400, IOException> as400, JournalInfo journalInfo, int journalBufferSize,
         boolean filtering, JournalCode[] filterCodes, List<FileFilter> includeFiles, int maxServerSideEntries,
-        File dumpFolder, long journalCacheDelay, long pollInterval) {
+        File dumpFolder) {
 
     public static final int DEFAULT_MAX_SERVER_SIDE_ENTRIES = 1000000;
 }

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/RetrieveConfig.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/RetrieveConfig.java
@@ -15,7 +15,7 @@ import io.debezium.ibmi.db2.journal.retrieve.RetrievalCriteria.JournalCode;
 
 public record RetrieveConfig(Connect<AS400, IOException> as400, JournalInfo journalInfo, int journalBufferSize,
         boolean filtering, JournalCode[] filterCodes, List<FileFilter> includeFiles, int maxServerSideEntries,
-        File dumpFolder) {
+        File dumpFolder, long journalCacheDelay, long pollInterval) {
 
     public static final int DEFAULT_MAX_SERVER_SIDE_ENTRIES = 1000000;
 }

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/RetrieveConfigBuilder.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/RetrieveConfigBuilder.java
@@ -29,8 +29,6 @@ public class RetrieveConfigBuilder {
     private List<FileFilter> includeFiles = Collections.<FileFilter> emptyList();
     private int maxServerSideEntries = RetrieveConfig.DEFAULT_MAX_SERVER_SIDE_ENTRIES;
     private boolean filtering;
-    private long journalCacheDelay = 35000;
-    private long pollInterval = 2000;
 
     public RetrieveConfigBuilder() {
     }
@@ -103,18 +101,7 @@ public class RetrieveConfigBuilder {
         return this;
     }
 
-    public RetrieveConfigBuilder withJournalCacheDelay(long journalCacheDelay) {
-        this.journalCacheDelay = journalCacheDelay;
-        return this;
-    }
-
-    public RetrieveConfigBuilder withPollInterval(long pollInterval) {
-        this.pollInterval = pollInterval;
-        return this;
-    }
-
     public RetrieveConfig build() {
-        return new RetrieveConfig(as400, journalInfo, journalBufferSize, filtering, filterCodes, includeFiles, maxServerSideEntries, dumpFolder, journalCacheDelay,
-                pollInterval);
+        return new RetrieveConfig(as400, journalInfo, journalBufferSize, filtering, filterCodes, includeFiles, maxServerSideEntries, dumpFolder);
     }
 }

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/RetrieveConfigBuilder.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/RetrieveConfigBuilder.java
@@ -29,6 +29,8 @@ public class RetrieveConfigBuilder {
     private List<FileFilter> includeFiles = Collections.<FileFilter> emptyList();
     private int maxServerSideEntries = RetrieveConfig.DEFAULT_MAX_SERVER_SIDE_ENTRIES;
     private boolean filtering;
+    private long journalCacheDelay = 35000;
+    private long pollInterval = 2000;
 
     public RetrieveConfigBuilder() {
     }
@@ -101,7 +103,18 @@ public class RetrieveConfigBuilder {
         return this;
     }
 
+    public RetrieveConfigBuilder withJournalCacheDelay(long journalCacheDelay) {
+        this.journalCacheDelay = journalCacheDelay;
+        return this;
+    }
+
+    public RetrieveConfigBuilder withPollInterval(long pollInterval) {
+        this.pollInterval = pollInterval;
+        return this;
+    }
+
     public RetrieveConfig build() {
-        return new RetrieveConfig(as400, journalInfo, journalBufferSize, filtering, filterCodes, includeFiles, maxServerSideEntries, dumpFolder);
+        return new RetrieveConfig(as400, journalInfo, journalBufferSize, filtering, filterCodes, includeFiles, maxServerSideEntries, dumpFolder, journalCacheDelay,
+                pollInterval);
     }
 }

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/exception/InvalidPositionException.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/exception/InvalidPositionException.java
@@ -5,7 +5,7 @@
  */
 package io.debezium.ibmi.db2.journal.retrieve.exception;
 
-public class InvalidPositionException extends Exception {
+public class InvalidPositionException extends FatalException {
 
     public InvalidPositionException(String message) {
         super(message);

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/exception/LostJournalException.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/exception/LostJournalException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.ibmi.db2.journal.retrieve.exception;
+
+/**
+ * Action needed to restream or we have lost data
+ */
+public class LostJournalException extends Exception {
+
+    public LostJournalException(String message) {
+        super(message);
+    }
+
+    public LostJournalException(Throwable cause) {
+        super(cause);
+    }
+
+    public LostJournalException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public LostJournalException(String message, Throwable cause, boolean enableSuppression,
+                                boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+}

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/exception/RetrieveJournalException.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/exception/RetrieveJournalException.java
@@ -1,0 +1,9 @@
+package io.debezium.ibmi.db2.journal.retrieve.exception;
+
+public class RetrieveJournalException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public RetrieveJournalException(String message) {
+        super(message);
+    }
+}

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/exception/RetrieveJournalException.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/exception/RetrieveJournalException.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.ibmi.db2.journal.retrieve.exception;
 
 public class RetrieveJournalException extends RuntimeException {

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/test/DebugJournal.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/test/DebugJournal.java
@@ -38,12 +38,12 @@ public class DebugJournal {
         final Connect<AS400, IOException> as400Connect = connector.getAs400();
         final Connect<Connection, SQLException> sqlConnect = connector.getJdbc();
         final String schema = connector.getSchema();
-        JournalInfoRetrieval jir = new JournalInfoRetrieval();
+        JournalInfoRetrieval jir = new JournalInfoRetrieval(35000, 2000);
 
         final byte[] data = Files.readAllBytes(Paths.get("C:\\dev\\kafka\\journal-parsing\\good-journal\\201218-0616-0"));
         final JournalInfo journal = jir.getJournal(as400Connect.connection(), schema);
         final RetrieveConfig config = new RetrieveConfigBuilder().withAs400(as400Connect).withJournalInfo(journal).build();
-        final RetrieveJournal rnj = new RetrieveJournal(config, new JournalInfoRetrieval());
+        final RetrieveJournal rnj = new RetrieveJournal(config, jir);
 
         rnj.setOutputData(data,
                 new FirstHeader(data.length, 0, data.length, OffsetStatus.NO_DATA, new JournalProcessedPosition()),

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/test/DebugJournal.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/test/DebugJournal.java
@@ -38,9 +38,10 @@ public class DebugJournal {
         final Connect<AS400, IOException> as400Connect = connector.getAs400();
         final Connect<Connection, SQLException> sqlConnect = connector.getJdbc();
         final String schema = connector.getSchema();
+        JournalInfoRetrieval jir = new JournalInfoRetrieval();
 
         final byte[] data = Files.readAllBytes(Paths.get("C:\\dev\\kafka\\journal-parsing\\good-journal\\201218-0616-0"));
-        final JournalInfo journal = JournalInfoRetrieval.getJournal(as400Connect.connection(), schema);
+        final JournalInfo journal = jir.getJournal(as400Connect.connection(), schema);
         final RetrieveConfig config = new RetrieveConfigBuilder().withAs400(as400Connect).withJournalInfo(journal).build();
         final RetrieveJournal rnj = new RetrieveJournal(config, new JournalInfoRetrieval());
 

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/test/DebugJournal.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/test/DebugJournal.java
@@ -38,7 +38,7 @@ public class DebugJournal {
         final Connect<AS400, IOException> as400Connect = connector.getAs400();
         final Connect<Connection, SQLException> sqlConnect = connector.getJdbc();
         final String schema = connector.getSchema();
-        JournalInfoRetrieval jir = new JournalInfoRetrieval(35000, 2000);
+        JournalInfoRetrieval jir = new JournalInfoRetrieval(30000, 5000, 2000);
 
         final byte[] data = Files.readAllBytes(Paths.get("C:\\dev\\kafka\\journal-parsing\\good-journal\\201218-0616-0"));
         final JournalInfo journal = jir.getJournal(as400Connect.connection(), schema);

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/test/JournalFilterTimeout.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/test/JournalFilterTimeout.java
@@ -37,7 +37,7 @@ public class JournalFilterTimeout {
     private static final Logger log = LoggerFactory.getLogger(JournalFilterTimeout.class);
 
     private static SchemaCacheHash schemaCache = new SchemaCacheHash();
-    private static JournalInfoRetrieval journalInfoRetrieval = new JournalInfoRetrieval(35000, 2000);
+    private static JournalInfoRetrieval journalInfoRetrieval = new JournalInfoRetrieval(30000, 5000, 2000);
 
     public static void main(String[] args) throws Exception {
         final TestConnector connector = new TestConnector();

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/test/JournalInfoMain.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/test/JournalInfoMain.java
@@ -26,7 +26,7 @@ public class JournalInfoMain {
         TestConnector connector = new TestConnector();
         Connect<AS400, IOException> as400Connect = connector.getAs400();
         String schema = connector.getSchema();
-        JournalInfoRetrieval journalInfoRetrieval = new JournalInfoRetrieval();
+        JournalInfoRetrieval journalInfoRetrieval = new JournalInfoRetrieval(35000, 2000);
         JournalInfo ji = journalInfoRetrieval.getJournal(as400Connect.connection(), schema, "PERSON");
 
         List<DetailedJournalReceiver> jri = journalInfoRetrieval.getReceivers(as400Connect.connection(), ji);

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/test/JournalInfoMain.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/test/JournalInfoMain.java
@@ -26,7 +26,7 @@ public class JournalInfoMain {
         TestConnector connector = new TestConnector();
         Connect<AS400, IOException> as400Connect = connector.getAs400();
         String schema = connector.getSchema();
-        JournalInfoRetrieval journalInfoRetrieval = new JournalInfoRetrieval(35000, 2000);
+        JournalInfoRetrieval journalInfoRetrieval = new JournalInfoRetrieval(30000, 5000, 2000);
         JournalInfo ji = journalInfoRetrieval.getJournal(as400Connect.connection(), schema, "PERSON");
 
         List<DetailedJournalReceiver> jri = journalInfoRetrieval.getReceivers(as400Connect.connection(), ji);

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/DelayedDetailedJournalReceiverTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/DelayedDetailedJournalReceiverTest.java
@@ -6,7 +6,9 @@
 package io.debezium.ibmi.db2.journal.retrieve;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigInteger;
 import java.util.Date;
@@ -91,47 +93,34 @@ class DelayedDetailedJournalReceiverTest {
     }
 
     @Test
-    void testReceiverIsAvailableWithinTimingMargin() {
-        DetailedJournalReceiver receiver = createReceiver("MARGIN");
-        buffer.addDetailedReceiver(receiver);
-        // 20% margin for 2000ms delay is 400ms
-        long margin = (long) (2000 * 0.2);
-        // Test just before lower bound (should be null)
-        fakeTime.addAndGet(1599); // 2000 - 401
-        assertNull(buffer.getDelayedReceiver(), "Should be null before margin lower bound");
-        // Test at lower bound (should be available)
-        fakeTime.addAndGet(1); // Now at 1600ms
-        DetailedJournalReceiver resultLower = buffer.getDelayedReceiver();
-        assertEquals(receiver, resultLower, "Should return receiver at margin lower bound");
-        // Add another receiver for upper bound test
-        DetailedJournalReceiver receiver2 = createReceiver("MARGIN2");
-        buffer.addDetailedReceiver(receiver2);
-        fakeTime.addAndGet(799); // 1600 + 799 = 2399ms
-        assertNull(buffer.getDelayedReceiver(), "Should be null just before margin upper bound");
-        fakeTime.addAndGet(1); // Now at 2400ms
-        DetailedJournalReceiver resultUpper = buffer.getDelayedReceiver();
-        assertEquals(receiver2, resultUpper, "Should return receiver at margin upper bound");
-    }
-
-    @Test
-    void testAddRateAllows20PercentFasterButRetrievalIsStrict() {
-        DetailedJournalReceiver receiver1 = createReceiver("FAST1");
-        buffer.addDetailedReceiver(receiver1);
+    void testAddRateAllows20PercentFasterAdddition() {
+        DetailedJournalReceiver receiver1 = createReceiver("INITIAL");
+        boolean added1 = buffer.addDetailedReceiver(receiver1);
+        assertTrue(added1, "First receiver should be added successfully");
         // Try to add another receiver 20% faster than poll interval
-        long minInterval = (long) (2000 * (1 - DelayedDetailedJournalReceiver.TIMING_ALLOWANCE_RATIO) + 1); // buffer.entries includes 20% margin + 1 for rounding
+        long minInterval = buffer.minDelayBetweenReadingsWithAllowance();
         fakeTime.addAndGet(minInterval - 1); // Just before allowed interval
-        DetailedJournalReceiver receiver2 = createReceiver("FAST2");
-        buffer.addDetailedReceiver(receiver2); // Should be skipped
+        DetailedJournalReceiver receiver2 = createReceiver("TOO_FAST");
+        boolean addedTooFast = buffer.addDetailedReceiver(receiver2); // Should be skipped
+        assertFalse(addedTooFast, "skipped adding too fast");
         // Add after allowed interval
-        fakeTime.addAndGet(1); // Now at minInterval
-        DetailedJournalReceiver receiver3 = createReceiver("FAST3");
-        buffer.addDetailedReceiver(receiver3); // Should be accepted
+        fakeTime.addAndGet(2); // Now at minInterval
+        DetailedJournalReceiver receiver3 = createReceiver("JUST_ALLOWED");
+        boolean addedJustAllowed = buffer.addDetailedReceiver(receiver3); // Should be accepted
+        assertTrue(addedJustAllowed, "added slightly fast but within allowance");
         // Advance time to allow retrieval
         fakeTime.addAndGet(2000);
-        DetailedJournalReceiver result1 = buffer.getDelayedReceiver();
-        assertEquals(receiver1, result1, "Should return first receiver after delay");
-        DetailedJournalReceiver result2 = buffer.getDelayedReceiver();
-        assertEquals(receiver3, result2, "Should return third receiver after delay (second was skipped)");
-        assertNull(buffer.getDelayedReceiver(), "No more receivers should be available");
+
+        fakeTime.set(2000 + 1); // Ensure enough time has passed for first receiver
+        DetailedJournalReceiver firstResult = buffer.getDelayedReceiver();
+        assertNull(buffer.getDelayedReceiver(), "Should return first receiver");
+
+        fakeTime.addAndGet(minInterval - 1);
+        assertEquals(receiver1, firstResult, "nothing there for the too fast");
+
+        fakeTime.addAndGet(1);
+        // get latest receiver
+        DetailedJournalReceiver resultJustInTime = buffer.getDelayedReceiver();
+        assertEquals(receiver3, resultJustInTime, "Should return third receiver after delay (second was skipped)");
     }
 }

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/DelayedDetailedJournalReceiverTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/DelayedDetailedJournalReceiverTest.java
@@ -1,0 +1,86 @@
+package io.debezium.ibmi.db2.journal.retrieve;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigInteger;
+import java.util.Date;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.ibmi.db2.journal.retrieve.rnrn0200.DetailedJournalReceiver;
+import io.debezium.ibmi.db2.journal.retrieve.rnrn0200.JournalReceiverInfo;
+import io.debezium.ibmi.db2.journal.retrieve.rnrn0200.JournalStatus;
+
+class DelayedDetailedJournalReceiverTest {
+    private AtomicLong fakeTime;
+    private Supplier<Long> timeSupplier;
+    private DelayedDetailedJournalReceiver buffer;
+
+    private DetailedJournalReceiver createReceiver(String id) {
+        JournalReceiverInfo info = new JournalReceiverInfo(null, new Date(0), JournalStatus.Attached, Optional.empty());
+        return new DetailedJournalReceiver(info, BigInteger.ZERO, BigInteger.ZERO, Optional.empty(), 0L, 0L);
+    }
+
+    @BeforeEach
+    void setup() {
+        fakeTime = new AtomicLong(0);
+        timeSupplier = fakeTime::get;
+        // 2 second delay, 1000ms poll interval
+        buffer = new DelayedDetailedJournalReceiver(2000, 1000, timeSupplier);
+    }
+
+    @Test
+    void testReceiverIsDelayed() {
+        DetailedJournalReceiver receiver = createReceiver("A");
+        buffer.addDetailedReceiver(receiver);
+        // Should not be available before 2 seconds
+        assertNull(buffer.getDelayedReceiver(), "Should be null before delay");
+        fakeTime.addAndGet(1999);
+        assertNull(buffer.getDelayedReceiver(), "Should still be null just before delay");
+        fakeTime.addAndGet(2); // Now at 2001ms
+        DetailedJournalReceiver result = buffer.getDelayedReceiver();
+        assertEquals(receiver, result, "Should return receiver after delay");
+    }
+
+    @Test
+    void testMultipleReceiversOrderAndDelay() {
+        DetailedJournalReceiver r1 = createReceiver("R1");
+        DetailedJournalReceiver r2 = createReceiver("R2");
+        buffer.addDetailedReceiver(r1);
+        fakeTime.addAndGet(1000); // 1s later
+        buffer.addDetailedReceiver(r2);
+        // Not enough time for either
+        fakeTime.addAndGet(999);
+        assertNull(buffer.getDelayedReceiver(), "Should be null before delay for r1");
+        fakeTime.addAndGet(2); // Now at 2001ms since r1
+        DetailedJournalReceiver result1 = buffer.getDelayedReceiver();
+        assertEquals(r1, result1, "Should return r1 after delay");
+        assertNull(buffer.getDelayedReceiver(), "Should be null before delay for r2");
+        fakeTime.addAndGet(999); // Now at 2000ms since r2
+        fakeTime.addAndGet(2); // Now at 2001ms since r2
+        DetailedJournalReceiver result2 = buffer.getDelayedReceiver();
+        assertEquals(r2, result2, "Should return r2 after delay");
+    }
+
+    @Test
+    void testAddTooQuicklyIsSkipped() {
+        DetailedJournalReceiver r1 = createReceiver("R1");
+        DetailedJournalReceiver r2 = createReceiver("R2");
+        buffer.addDetailedReceiver(r1);
+        // Try to add r2 immediately, should be skipped
+        buffer.addDetailedReceiver(r2);
+        fakeTime.addAndGet(2001);
+        DetailedJournalReceiver result = buffer.getDelayedReceiver();
+        assertEquals(r1, result, "Should return r1 after delay");
+        assertNull(buffer.getDelayedReceiver(), "Should be null after r1 consumed");
+    }
+
+    @Test
+    void testNullIfNothingAdded() {
+        assertNull(buffer.getDelayedReceiver());
+    }
+}

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/DelayedDetailedJournalReceiverTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/DelayedDetailedJournalReceiverTest.java
@@ -89,4 +89,49 @@ class DelayedDetailedJournalReceiverTest {
     void testNullIfNothingAdded() {
         assertNull(buffer.getDelayedReceiver());
     }
+
+    @Test
+    void testReceiverIsAvailableWithinTimingMargin() {
+        DetailedJournalReceiver receiver = createReceiver("MARGIN");
+        buffer.addDetailedReceiver(receiver);
+        // 20% margin for 2000ms delay is 400ms
+        long margin = (long) (2000 * 0.2);
+        // Test just before lower bound (should be null)
+        fakeTime.addAndGet(1599); // 2000 - 401
+        assertNull(buffer.getDelayedReceiver(), "Should be null before margin lower bound");
+        // Test at lower bound (should be available)
+        fakeTime.addAndGet(1); // Now at 1600ms
+        DetailedJournalReceiver resultLower = buffer.getDelayedReceiver();
+        assertEquals(receiver, resultLower, "Should return receiver at margin lower bound");
+        // Add another receiver for upper bound test
+        DetailedJournalReceiver receiver2 = createReceiver("MARGIN2");
+        buffer.addDetailedReceiver(receiver2);
+        fakeTime.addAndGet(799); // 1600 + 799 = 2399ms
+        assertNull(buffer.getDelayedReceiver(), "Should be null just before margin upper bound");
+        fakeTime.addAndGet(1); // Now at 2400ms
+        DetailedJournalReceiver resultUpper = buffer.getDelayedReceiver();
+        assertEquals(receiver2, resultUpper, "Should return receiver at margin upper bound");
+    }
+
+    @Test
+    void testAddRateAllows20PercentFasterButRetrievalIsStrict() {
+        DetailedJournalReceiver receiver1 = createReceiver("FAST1");
+        buffer.addDetailedReceiver(receiver1);
+        // Try to add another receiver 20% faster than poll interval
+        long minInterval = (long) (2000 * (1 - DelayedDetailedJournalReceiver.TIMING_ALLOWANCE_RATIO) + 1); // buffer.entries includes 20% margin + 1 for rounding
+        fakeTime.addAndGet(minInterval - 1); // Just before allowed interval
+        DetailedJournalReceiver receiver2 = createReceiver("FAST2");
+        buffer.addDetailedReceiver(receiver2); // Should be skipped
+        // Add after allowed interval
+        fakeTime.addAndGet(1); // Now at minInterval
+        DetailedJournalReceiver receiver3 = createReceiver("FAST3");
+        buffer.addDetailedReceiver(receiver3); // Should be accepted
+        // Advance time to allow retrieval
+        fakeTime.addAndGet(2000);
+        DetailedJournalReceiver result1 = buffer.getDelayedReceiver();
+        assertEquals(receiver1, result1, "Should return first receiver after delay");
+        DetailedJournalReceiver result2 = buffer.getDelayedReceiver();
+        assertEquals(receiver3, result2, "Should return third receiver after delay (second was skipped)");
+        assertNull(buffer.getDelayedReceiver(), "No more receivers should be available");
+    }
 }

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/DelayedDetailedJournalReceiverTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/DelayedDetailedJournalReceiverTest.java
@@ -1,6 +1,12 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.ibmi.db2.journal.retrieve;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.math.BigInteger;
 import java.util.Date;

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPaginationTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPaginationTest.java
@@ -37,7 +37,7 @@ class ReceiverPaginationTest {
     ReceiverPagination receivers;
     @Mock
     JournalInfoRetrieval journalInfoRetrieval;
-    JournalInfo journalInfo = new JournalInfo("journal", "journallib");
+    JournalInfo journalInfo = new JournalInfo("journal", "journallib", false);
     @Mock
     AS400 as400;
 

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPaginationTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPaginationTest.java
@@ -64,14 +64,14 @@ class ReceiverPaginationTest {
 
         when(journalInfoRetrieval.getReceivers(any(), any())).thenReturn(list);
 
-        when(journalInfoRetrieval.getCurrentDetailedJournalReceiver(any(), any())).thenReturn(dr1);
+        when(journalInfoRetrieval.getDelayedDetailedJournalReceiver(any(), any())).thenReturn(Optional.of(dr1));
 
         final JournalProcessedPosition startPosition = new JournalProcessedPosition(BigInteger.ONE,
                 new JournalReceiver("j1", "jlib"), Instant.ofEpochSecond(0), true);
-        final PositionRange result = jreceivers.findRange(as400, startPosition);
+        final Optional<PositionRange> result = jreceivers.findRange(as400, startPosition);
         final PositionRange rangeAnswer = new PositionRange(false, startPosition,
                 new JournalPosition(dr1.end(), dr1.info().receiver()));
-        assertEquals(rangeAnswer, result);
+        assertEquals(rangeAnswer, result.get());
     }
 
     @Test
@@ -82,14 +82,14 @@ class ReceiverPaginationTest {
 
         when(journalInfoRetrieval.getReceivers(any(), any())).thenReturn(list);
 
-        when(journalInfoRetrieval.getCurrentDetailedJournalReceiver(any(), any())).thenReturn(dr2);
+        when(journalInfoRetrieval.getDelayedDetailedJournalReceiver(any(), any())).thenReturn(Optional.of(dr2));
 
         final JournalProcessedPosition startPosition = new JournalProcessedPosition(BigInteger.ONE,
                 new JournalReceiver("j1", "jlib"), Instant.ofEpochSecond(0), true);
-        final PositionRange result = jreceivers.findRange(as400, startPosition);
+        final Optional<PositionRange> result = jreceivers.findRange(as400, startPosition);
         final PositionRange rangeAnswer = new PositionRange(false, startPosition,
                 new JournalPosition(dr2.end(), dr2.info().receiver()));
-        assertEquals(rangeAnswer, result);
+        assertEquals(rangeAnswer, result.get());
     }
 
     @Test
@@ -102,22 +102,21 @@ class ReceiverPaginationTest {
         final DetailedJournalReceiver detailedEnd2 = dr3;
         final List<DetailedJournalReceiver> list2 = Arrays.asList(dr1, dr2, detailedEnd2);
         when(journalInfoRetrieval.getReceivers(any(), any())).thenReturn(list).thenReturn(list2);
-        when(journalInfoRetrieval.getCurrentDetailedJournalReceiver(any(), any())).thenReturn(detailedEnd)
-                .thenReturn(detailedEnd2);
+        when(journalInfoRetrieval.getDelayedDetailedJournalReceiver(any(), any())).thenReturn(Optional.of(detailedEnd)).thenReturn(Optional.of(detailedEnd2));
 
         final JournalProcessedPosition startPosition = new JournalProcessedPosition(BigInteger.ONE,
                 new JournalReceiver("j1", "jlib"), Instant.ofEpochSecond(0), true);
-        final PositionRange result = jreceivers.findRange(as400, startPosition);
+        final Optional<PositionRange> result = jreceivers.findRange(as400, startPosition);
         final PositionRange rangeAnswer = new PositionRange(false, startPosition,
                 new JournalPosition(BigInteger.valueOf(8), detailedEnd.info().receiver()));
-        assertEquals(rangeAnswer, result);
+        assertEquals(rangeAnswer, result.get());
 
         final JournalProcessedPosition startPosition2 = new JournalProcessedPosition(BigInteger.valueOf(2),
                 new JournalReceiver("j2", "jlib"), Instant.ofEpochSecond(0), true);
-        final PositionRange result2 = jreceivers.findRange(as400, startPosition2);
+        final Optional<PositionRange> result2 = jreceivers.findRange(as400, startPosition2);
         final PositionRange rangeAnswer2 = new PositionRange(false, startPosition2,
                 new JournalPosition(BigInteger.valueOf(17), detailedEnd2.info().receiver()));
-        assertEquals(rangeAnswer2, result2);
+        assertEquals(rangeAnswer2, result2.get());
 
     }
 

--- a/jt400-override-ccsid/pom.xml
+++ b/jt400-override-ccsid/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-reactor-ibmi</artifactId>
-        <version>3.3.0.Final_FNZ1</version>
+        <version>3.3.1.Final_FNZ1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jt400-override-ccsid/pom.xml
+++ b/jt400-override-ccsid/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-reactor-ibmi</artifactId>
-        <version>3.3.1.Final_FNZ1</version>
+        <version>3.3.1.Final_FNZ2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.3.0.Final_FNZ1</version>
+        <version>3.3.1.Final_FNZ1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>debezium-connector-reactor-ibmi</artifactId>
-    <version>3.3.0.Final_FNZ1</version>
+    <version>3.3.1.Final_FNZ1</version>
     <packaging>pom</packaging>
     <name>Debezium Connector Reactor for IBM iSeries Db2</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>debezium-connector-reactor-ibmi</artifactId>
-    <version>3.3.1.Final_FNZ1</version>
+    <version>3.3.1.Final_FNZ2</version>
     <packaging>pom</packaging>
     <name>Debezium Connector Reactor for IBM iSeries Db2</name>
 


### PR DESCRIPTION
Add delay when journal caching is turned on. 
Add configurable additional delay as we don't know how long after the flush the journal will be available.
Use the additional delay when set and not caching as we have seen similar behavour when not caching.