### PR TITLE
fix: TT-1727 add validation to try and avoid negative sequence ranges

### DIFF
--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
@@ -92,24 +92,15 @@ public class ReceiverPagination {
             
             cachedEndPosition = endPosition;
         }
-        updateEndPosition(cachedReceivers, endPosition);
 
-        Optional<PositionRange> endOpt = findPosition(startPosition, maxServerSideEntriesBI, cachedReceivers);
+        Optional<PositionRange> endOpt = findPosition(startPosition, endPosition, maxServerSideEntriesBI, cachedReceivers);
         if (endOpt.isEmpty()) {
-            log.warn("retrying to find end offset");
-            cachedReceivers = journalInfoRetrieval.getReceivers(as400, journalInfo);
-            endOpt = findPosition(startPosition, maxServerSideEntriesBI, cachedReceivers);
-            if (endOpt.isEmpty()) {
-                throw new InvalidPositionException("unable to find receiver " + startPosition + " in " + cachedReceivers);
-            }
+    		String receivers = cachedReceivers.stream().map(DetailedJournalReceiver::toString).collect(Collectors.joining(","));
+    		throw new InvalidPositionException(String.format("invalid receiver list after %d retries position was %s receivers were %s", receiverListRetries, startPosition, receivers));
         }
 
         log.debug("end {} journals {}", endPosition, cachedReceivers);
-
-        final JournalProcessedPosition startf = new JournalProcessedPosition(startPosition);
-        return Optional.of(endOpt.orElseGet(
-                () -> new PositionRange(fromBeginning, startf,
-                        new JournalPosition(endPosition.end(), endPosition.info().receiver()))));
+        return endOpt;
     }
     
     static boolean isValid(JournalProcessedPosition startPosition, DetailedJournalReceiver endPositionOpt, List<DetailedJournalReceiver> receivers) {
@@ -134,18 +125,6 @@ public class ReceiverPagination {
 		}
 		return false;
 	}
-
-    static void updateEndPosition(List<DetailedJournalReceiver> list, DetailedJournalReceiver endPosition) {
-        // should be last entry
-        for (int i = list.size() - 1; i >= 0; i--) {
-            final DetailedJournalReceiver d = list.get(i);
-            if (d.isSameReceiver(endPosition)) {
-                list.set(i, endPosition);
-                return;
-            }
-        }
-        list.add(endPosition);
-    }
 
     /**
      * only valid when startPosition and endJournalPosition are the same receiver and library
@@ -177,26 +156,32 @@ public class ReceiverPagination {
      * @param receivers
      * @return try and find end position at most offsetFromStart from start using the receiver list
      */
-    Optional<PositionRange> findPosition(JournalProcessedPosition startPosition, BigInteger maxEntries,
+    Optional<PositionRange> findPosition(JournalProcessedPosition startPosition, DetailedJournalReceiver endPosition, BigInteger maxEntries,
                                          List<DetailedJournalReceiver> receivers)
             throws Exception {
 
         for (Iterator<DetailedJournalReceiver> it = receivers.iterator(); it.hasNext();) {
             DetailedJournalReceiver nextReceiver = it.next();
             if (nextReceiver.isSameReceiver(startPosition)) {
-                if (startEqualsEndAndProcessed(startPosition, nextReceiver)) {
-                    if (it.hasNext()) {
+                if (startEqualsEndAndProcessed(startPosition, nextReceiver)) { // finished processing this receiver
+                    if (it.hasNext()) { // paginate within next receiver if it exists
                         nextReceiver = it.next();
                         startPosition.setPosition(new JournalPosition(nextReceiver.start(), nextReceiver.info().receiver()), false);
+                        if (nextReceiver.isSameReceiver(endPosition)) { // delayed end offset is the next receiver to process
+                        	return Optional.of(
+                                    paginateInSameReceiver(startPosition, endPosition, maxEntries));
+                        }
+                        // just paginate within the receiver in the list
                         return Optional.of(
                                 paginateInSameReceiver(startPosition, nextReceiver, maxEntries));
                     }
                     else {
-                        // we're at the end and we've processed everything
+                        // we're at the end and we've processed everything, there are no more receivers
                         return Optional.of(
                                 paginateInSameReceiver(startPosition, nextReceiver, maxEntries));
                     }
                 }
+                // we haven't finished this receiver yet 
                 return Optional.of(
                         paginateInSameReceiver(startPosition, nextReceiver, maxEntries));
             }

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
@@ -67,8 +67,6 @@ public class ReceiverPagination {
         }
 
         if (cachedEndPosition.isSameReceiver(endPosition)) {
-            // refresh end position in cached list
-            updateEndPosition(cachedReceivers, endPosition);
             // we're currently on the same journal just check the relative offset is within range
             if (startPosition.isSameReceiver(endPosition)) {
                 return Optional.of(paginateInSameReceiver(startPosition, endPosition, maxServerSideEntriesBI));
@@ -94,6 +92,7 @@ public class ReceiverPagination {
             
             cachedEndPosition = endPosition;
         }
+        updateEndPosition(cachedReceivers, endPosition);
 
         Optional<PositionRange> endOpt = findPosition(startPosition, maxServerSideEntriesBI, cachedReceivers);
         if (endOpt.isEmpty()) {

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
@@ -156,15 +156,17 @@ public class ReceiverPagination {
 
         for (Iterator<DetailedJournalReceiver> it = receivers.iterator(); it.hasNext();) {
             DetailedJournalReceiver nextReceiver = it.next();
+            if (nextReceiver.isSameReceiver(endPosition)) {
+            	nextReceiver = endPosition;
+            }
             if (nextReceiver.isSameReceiver(startPosition)) {
                 if (startEqualsEndAndProcessed(startPosition, nextReceiver)) { // finished processing this receiver
                     if (it.hasNext()) { // paginate within next receiver if it exists
                         nextReceiver = it.next();
-                        startPosition.setPosition(new JournalPosition(nextReceiver.start(), nextReceiver.info().receiver()), false);
-                        if (nextReceiver.isSameReceiver(endPosition)) { // delayed end offset is the next receiver to process
-                        	return Optional.of(
-                                    paginateInSameReceiver(startPosition, endPosition, maxEntries));
+                        if (nextReceiver.isSameReceiver(endPosition)) {
+                        	nextReceiver = endPosition;
                         }
+                        startPosition.setPosition(new JournalPosition(nextReceiver.start(), nextReceiver.info().receiver()), false);
                         // just paginate within the receiver in the list
                         return Optional.of(
                                 paginateInSameReceiver(startPosition, nextReceiver, maxEntries));

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
@@ -103,22 +103,16 @@ public class ReceiverPagination {
         return endOpt;
     }
     
-    static boolean isValid(JournalProcessedPosition startPosition, DetailedJournalReceiver endPositionOpt, List<DetailedJournalReceiver> receivers) {
+    static boolean isValid(JournalProcessedPosition startPosition, DetailedJournalReceiver endPosition, List<DetailedJournalReceiver> receivers) {
         for (int i = receivers.size() - 1; i >= 0; i--) {
             final DetailedJournalReceiver r = receivers.get(i);
-			if (r.isSameReceiver(endPositionOpt)) {
-				if (!r.isAttached()) {
-					log.warn("the current reciver {} is not attached {}, it is likely we have state data", r, endPositionOpt);
-					return false;
-				}
-			}
 			if (r.isSameReceiver(startPosition)) {
 				if (r.isAttached()) {
-					log.warn("we have a new receiver {} but the list shows the one we were processing before {} is still attached, it is likely we have state data", r, startPosition);
+					log.warn("receiver in the list {} is still attached, but our current position {} isn't the end poisition {}", r, startPosition, endPosition);
 					return false;
 				}
 				if (r.end().compareTo(startPosition.getOffset()) < 0) { 
-					log.warn("we have a new receiver but the end offset in the receiver list {} is less than the current position {}", r, startPosition);
+					log.warn("The end offset in the receiver list {} is less than the current position {}", r, startPosition);
 					return false;
 				}
 			}

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
@@ -75,50 +75,55 @@ public class ReceiverPagination {
         else {
             // last call to current position won't include the correct end offset so we need to refresh the list
             cachedReceivers = journalInfoRetrieval.getReceivers(as400, journalInfo);
-            
+
             if (!isValid(startPosition, endPosition, cachedReceivers)) {
-            	cachedReceivers = null;
-            	receiverListRetries++;
-            	if (receiverListRetries < 100) {
-            		log.debug("assuming our receiver list is stale");
-            		return Optional.<PositionRange>empty();
-            	} else {
-            		String receivers = cachedReceivers.stream().map(DetailedJournalReceiver::toString).collect(Collectors.joining(","));
-            		throw new InvalidPositionException(String.format("invalid receiver list after %d retries position was %s receivers were %s", receiverListRetries, startPosition, receivers));
-            	}
-            } else {
-            	receiverListRetries = 0;
-            }       
-            
+                cachedReceivers = null;
+                receiverListRetries++;
+                if (receiverListRetries < 100) {
+                    log.debug("assuming our receiver list is stale");
+                    return Optional.<PositionRange> empty();
+                }
+                else {
+                    String receivers = cachedReceivers.stream().map(DetailedJournalReceiver::toString).collect(Collectors.joining(","));
+                    throw new InvalidPositionException(
+                            String.format("invalid receiver list after %d retries position was %s receivers were %s", receiverListRetries, startPosition, receivers));
+                }
+            }
+            else {
+                receiverListRetries = 0;
+            }
+
             cachedEndPosition = endPosition;
         }
 
         Optional<PositionRange> endOpt = findPosition(startPosition, endPosition, maxServerSideEntriesBI, cachedReceivers);
         if (endOpt.isEmpty()) {
-    		String receivers = cachedReceivers.stream().map(DetailedJournalReceiver::toString).collect(Collectors.joining(","));
-    		throw new InvalidPositionException(String.format("invalid receiver list after %d retries position was %s receivers were %s", receiverListRetries, startPosition, receivers));
+            String receivers = cachedReceivers.stream().map(DetailedJournalReceiver::toString).collect(Collectors.joining(","));
+            throw new InvalidPositionException(
+                    String.format("invalid receiver list after %d retries position was %s receivers were %s", receiverListRetries, startPosition, receivers));
         }
 
         log.debug("end {} journals {}", endPosition, cachedReceivers);
         return endOpt;
     }
-    
+
     static boolean isValid(JournalProcessedPosition startPosition, DetailedJournalReceiver endPosition, List<DetailedJournalReceiver> receivers) {
         for (int i = receivers.size() - 1; i >= 0; i--) {
             final DetailedJournalReceiver r = receivers.get(i);
-			if (r.isSameReceiver(startPosition)) {
-				if (r.isAttached()) {
-					log.warn("receiver matching our position in the list {} is still attached, but our current position {} isn't the end poisition {}", r, startPosition, endPosition);
-					return false;
-				}
-				if (r.end().compareTo(startPosition.getOffset()) < 0) { 
-					log.warn("The end offset in the receiver list {} is less than the current position {}", r, startPosition);
-					return false;
-				}
-			}
-		}
-		return false;
-	}
+            if (r.isSameReceiver(startPosition)) {
+                if (r.isAttached()) {
+                    log.warn("receiver matching our position in the list {} is still attached, but our current position {} isn't the end poisition {}", r, startPosition,
+                            endPosition);
+                    return false;
+                }
+                if (r.end().compareTo(startPosition.getOffset()) < 0) {
+                    log.warn("The end offset in the receiver list {} is less than the current position {}", r, startPosition);
+                    return false;
+                }
+            }
+        }
+        return false;
+    }
 
     /**
      * only valid when startPosition and endJournalPosition are the same receiver and library
@@ -157,14 +162,14 @@ public class ReceiverPagination {
         for (Iterator<DetailedJournalReceiver> it = receivers.iterator(); it.hasNext();) {
             DetailedJournalReceiver nextReceiver = it.next();
             if (nextReceiver.isSameReceiver(endPosition)) {
-            	nextReceiver = endPosition;
+                nextReceiver = endPosition;
             }
             if (nextReceiver.isSameReceiver(startPosition)) {
                 if (startEqualsEndAndProcessed(startPosition, nextReceiver)) { // finished processing this receiver
                     if (it.hasNext()) { // paginate within next receiver if it exists
                         nextReceiver = it.next();
                         if (nextReceiver.isSameReceiver(endPosition)) {
-                        	nextReceiver = endPosition;
+                            nextReceiver = endPosition;
                         }
                         startPosition.setPosition(new JournalPosition(nextReceiver.start(), nextReceiver.info().receiver()), false);
                         // just paginate within the receiver in the list
@@ -177,7 +182,7 @@ public class ReceiverPagination {
                                 paginateInSameReceiver(startPosition, nextReceiver, maxEntries));
                     }
                 }
-                // we haven't finished this receiver yet 
+                // we haven't finished this receiver yet
                 return Optional.of(
                         paginateInSameReceiver(startPosition, nextReceiver, maxEntries));
             }

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
@@ -10,6 +10,7 @@ import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +28,7 @@ public class ReceiverPagination {
     private final BigInteger maxServerSideEntriesBI;
     private DetailedJournalReceiver cachedEndPosition;
     private List<DetailedJournalReceiver> cachedReceivers = null;
+    private int receiverListRetries = 0;
 
     ReceiverPagination(JournalInfoRetrieval journalInfoRetrieval, int maxServerSideEntries, JournalInfo journalInfo) {
         this.journalInfoRetrieval = journalInfoRetrieval;
@@ -37,7 +39,7 @@ public class ReceiverPagination {
     Optional<PositionRange> findRange(AS400 as400, JournalProcessedPosition startPosition) throws Exception {
         final Optional<DetailedJournalReceiver> endPositionOpt = journalInfoRetrieval.getDelayedDetailedJournalReceiver(as400, journalInfo);
 
-        return endPositionOpt.map(endPosition -> {
+        return endPositionOpt.flatMap(endPosition -> {
             try {
                 return _findRange(as400, startPosition, endPosition);
             }
@@ -47,7 +49,7 @@ public class ReceiverPagination {
         });
     }
 
-    PositionRange _findRange(AS400 as400, JournalProcessedPosition startPosition, DetailedJournalReceiver endPosition) throws Exception {
+    Optional<PositionRange> _findRange(AS400 as400, JournalProcessedPosition startPosition, DetailedJournalReceiver endPosition) throws Exception {
         final BigInteger start = startPosition.getOffset();
         final boolean fromBeginning = !startPosition.isOffsetSet() || start.equals(BigInteger.ZERO);
 
@@ -68,14 +70,28 @@ public class ReceiverPagination {
             // refresh end position in cached list
             updateEndPosition(cachedReceivers, endPosition);
             // we're currently on the same journal just check the relative offset is within range
-            // don't update the cache as we are not going to know the real end offset for this journal receiver until we move on to the next
             if (startPosition.isSameReceiver(endPosition)) {
-                return paginateInSameReceiver(startPosition, endPosition, maxServerSideEntriesBI);
+                return Optional.of(paginateInSameReceiver(startPosition, endPosition, maxServerSideEntriesBI));
             }
         }
         else {
             // last call to current position won't include the correct end offset so we need to refresh the list
             cachedReceivers = journalInfoRetrieval.getReceivers(as400, journalInfo);
+            
+            if (!isValid(startPosition, endPosition, cachedReceivers)) {
+            	cachedReceivers = null;
+            	receiverListRetries++;
+            	if (receiverListRetries < 100) {
+            		log.debug("assuming our receiver list is stale");
+            		return Optional.<PositionRange>empty();
+            	} else {
+            		String receivers = cachedReceivers.stream().map(DetailedJournalReceiver::toString).collect(Collectors.joining(","));
+            		throw new InvalidPositionException(String.format("invalid receiver list after %d retries position was %s receivers were %s", receiverListRetries, startPosition, receivers));
+            	}
+            } else {
+            	receiverListRetries = 0;
+            }       
+            
             cachedEndPosition = endPosition;
         }
 
@@ -92,10 +108,33 @@ public class ReceiverPagination {
         log.debug("end {} journals {}", endPosition, cachedReceivers);
 
         final JournalProcessedPosition startf = new JournalProcessedPosition(startPosition);
-        return endOpt.orElseGet(
+        return Optional.of(endOpt.orElseGet(
                 () -> new PositionRange(fromBeginning, startf,
-                        new JournalPosition(endPosition.end(), endPosition.info().receiver())));
+                        new JournalPosition(endPosition.end(), endPosition.info().receiver()))));
     }
+    
+    static boolean isValid(JournalProcessedPosition startPosition, DetailedJournalReceiver endPositionOpt, List<DetailedJournalReceiver> receivers) {
+        for (int i = receivers.size() - 1; i >= 0; i--) {
+            final DetailedJournalReceiver r = receivers.get(i);
+			if (r.isSameReceiver(endPositionOpt)) {
+				if (!r.isAttached()) {
+					log.warn("the current reciver {} is not attached {}, it is likely we have state data", r, endPositionOpt);
+					return false;
+				}
+			}
+			if (r.isSameReceiver(startPosition)) {
+				if (r.isAttached()) {
+					log.warn("we have a new receiver {} but the list shows the one we were processing before {} is still attached, it is likely we have state data", r, startPosition);
+					return false;
+				}
+				if (r.end().compareTo(startPosition.getOffset()) < 0) { 
+					log.warn("we have a new receiver but the end offset in the receiver list {} is less than the current position {}", r, startPosition);
+					return false;
+				}
+			}
+		}
+		return false;
+	}
 
     static void updateEndPosition(List<DetailedJournalReceiver> list, DetailedJournalReceiver endPosition) {
         // should be last entry

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
@@ -108,7 +108,7 @@ public class ReceiverPagination {
             final DetailedJournalReceiver r = receivers.get(i);
 			if (r.isSameReceiver(startPosition)) {
 				if (r.isAttached()) {
-					log.warn("receiver in the list {} is still attached, but our current position {} isn't the end poisition {}", r, startPosition, endPosition);
+					log.warn("receiver matching our position in the list {} is still attached, but our current position {} isn't the end poisition {}", r, startPosition, endPosition);
 					return false;
 				}
 				if (r.end().compareTo(startPosition.getOffset()) < 0) { 

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/rnrn0200/DetailedJournalReceiver.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/rnrn0200/DetailedJournalReceiver.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.ibmi.db2.journal.retrieve.JournalPosition;
 import io.debezium.ibmi.db2.journal.retrieve.JournalProcessedPosition;
 import io.debezium.ibmi.db2.journal.retrieve.JournalReceiver;
 
@@ -27,6 +28,13 @@ public record DetailedJournalReceiver(JournalReceiverInfo info, BigInteger start
                 this.maxEntryLength, this.numberOfEntries);
     }
 
+    public boolean isSameReceiver(JournalPosition position) {
+        if (info == null || position == null) {
+            return false;
+        }
+        return info.receiver().equals(position.getReceiver());
+    }
+    
     public boolean isSameReceiver(JournalProcessedPosition position) {
         if (info == null || position == null) {
             return false;

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/rnrn0200/DetailedJournalReceiver.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/rnrn0200/DetailedJournalReceiver.java
@@ -34,7 +34,7 @@ public record DetailedJournalReceiver(JournalReceiverInfo info, BigInteger start
         }
         return info.receiver().equals(position.getReceiver());
     }
-    
+
     public boolean isSameReceiver(JournalProcessedPosition position) {
         if (info == null || position == null) {
             return false;


### PR DESCRIPTION
We see requests from the current position to a sequence number before where we are

The code only ever adds to the sequence number (maxServerSideEntriesBI) or sets the sequence number to the end range for that receiver

We get the list of receivers and their ranges by calling QjoRtvJrnReceiverInformation 

I presume we are getting stale information and the end sequnce number being returned is old. This is only used when we are no longer on the latest receiver. Typically soon after a new receiver is allocated.